### PR TITLE
Fix naming

### DIFF
--- a/Sources/GRPCHealthService/Generated/health.grpc.swift
+++ b/Sources/GRPCHealthService/Generated/health.grpc.swift
@@ -52,13 +52,13 @@ package enum Grpc_Health_V1_Health {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    package typealias StreamingServiceProtocol = Grpc_Health_V1_HealthStreamingServiceProtocol
+    package typealias StreamingServiceProtocol = Grpc_Health_V1_Health_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    package typealias ServiceProtocol = Grpc_Health_V1_HealthServiceProtocol
+    package typealias ServiceProtocol = Grpc_Health_V1_Health_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    package typealias ClientProtocol = Grpc_Health_V1_HealthClientProtocol
+    package typealias ClientProtocol = Grpc_Health_V1_Health_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    package typealias Client = Grpc_Health_V1_HealthClient
+    package typealias Client = Grpc_Health_V1_Health_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -72,7 +72,7 @@ extension GRPCCore.ServiceDescriptor {
 /// RPCs. Its semantics are documented in
 /// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-package protocol Grpc_Health_V1_HealthStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+package protocol Grpc_Health_V1_Health_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// Check gets the health of the specified service. If the requested service
     /// is unknown, the call will fail with status NOT_FOUND. If the caller does
     /// not specify a service name, the server should respond with its overall
@@ -83,9 +83,9 @@ package protocol Grpc_Health_V1_HealthStreamingServiceProtocol: GRPCCore.Registr
     ///
     /// Check implementations should be idempotent and side effect free.
     func check(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Health_V1_HealthCheckRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Health_V1_HealthCheckResponse>
     
     /// Performs a watch for the serving status of the requested service.
     /// The server will immediately send back a message indicating the current
@@ -103,9 +103,9 @@ package protocol Grpc_Health_V1_HealthStreamingServiceProtocol: GRPCCore.Registr
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
     func watch(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Health_V1_HealthCheckRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Health_V1_HealthCheckResponse>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -142,7 +142,7 @@ extension Grpc_Health_V1_Health.StreamingServiceProtocol {
 /// RPCs. Its semantics are documented in
 /// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-package protocol Grpc_Health_V1_HealthServiceProtocol: Grpc_Health_V1_Health.StreamingServiceProtocol {
+package protocol Grpc_Health_V1_Health_ServiceProtocol: Grpc_Health_V1_Health.StreamingServiceProtocol {
     /// Check gets the health of the specified service. If the requested service
     /// is unknown, the call will fail with status NOT_FOUND. If the caller does
     /// not specify a service name, the server should respond with its overall
@@ -153,9 +153,9 @@ package protocol Grpc_Health_V1_HealthServiceProtocol: Grpc_Health_V1_Health.Str
     ///
     /// Check implementations should be idempotent and side effect free.
     func check(
-        request: GRPCCore.ServerRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ServerRequest<Grpc_Health_V1_HealthCheckRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Health_V1_HealthCheckResponse>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Health_V1_HealthCheckResponse>
     
     /// Performs a watch for the serving status of the requested service.
     /// The server will immediately send back a message indicating the current
@@ -173,31 +173,31 @@ package protocol Grpc_Health_V1_HealthServiceProtocol: Grpc_Health_V1_Health.Str
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
     func watch(
-        request: GRPCCore.ServerRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ServerRequest<Grpc_Health_V1_HealthCheckRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Health_V1_HealthCheckResponse>
 }
 
-/// Partial conformance to `Grpc_Health_V1_HealthStreamingServiceProtocol`.
+/// Partial conformance to `Grpc_Health_V1_Health_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ServiceProtocol {
     package func check(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Health_V1_HealthCheckRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Health_V1_HealthCheckResponse> {
         let response = try await self.check(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
     
     package func watch(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Health_V1_HealthCheckRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Health_V1_HealthCheckResponse> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Health_V1_HealthCheckResponse> {
         let response = try await self.watch(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
         return response
@@ -208,7 +208,7 @@ extension Grpc_Health_V1_Health.ServiceProtocol {
 /// RPCs. Its semantics are documented in
 /// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-package protocol Grpc_Health_V1_HealthClientProtocol: Sendable {
+package protocol Grpc_Health_V1_Health_ClientProtocol: Sendable {
     /// Check gets the health of the specified service. If the requested service
     /// is unknown, the call will fail with status NOT_FOUND. If the caller does
     /// not specify a service name, the server should respond with its overall
@@ -219,11 +219,11 @@ package protocol Grpc_Health_V1_HealthClientProtocol: Sendable {
     ///
     /// Check implementations should be idempotent and side effect free.
     func check<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// Performs a watch for the serving status of the requested service.
@@ -242,20 +242,20 @@ package protocol Grpc_Health_V1_HealthClientProtocol: Sendable {
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
     func watch<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ClientProtocol {
     package func check<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -269,9 +269,9 @@ extension Grpc_Health_V1_Health.ClientProtocol {
     }
     
     package func watch<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.watch(
             request: request,
@@ -298,11 +298,11 @@ extension Grpc_Health_V1_Health.ClientProtocol {
         _ message: Grpc_Health_V1_HealthCheckRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>(
+        let request = GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>(
             message: message,
             metadata: metadata
         )
@@ -332,9 +332,9 @@ extension Grpc_Health_V1_Health.ClientProtocol {
         _ message: Grpc_Health_V1_HealthCheckRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> Result
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>(
+        let request = GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>(
             message: message,
             metadata: metadata
         )
@@ -350,7 +350,7 @@ extension Grpc_Health_V1_Health.ClientProtocol {
 /// RPCs. Its semantics are documented in
 /// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol {
+package struct Grpc_Health_V1_Health_Client: Grpc_Health_V1_Health.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     package init(wrapping client: GRPCCore.GRPCClient) {
@@ -367,11 +367,11 @@ package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol
     ///
     /// Check implementations should be idempotent and side effect free.
     package func check<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Health_V1_HealthCheckResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -401,11 +401,11 @@ package struct Grpc_Health_V1_HealthClient: Grpc_Health_V1_Health.ClientProtocol
     /// call.  If the call terminates with any other status (including OK),
     /// clients should retry the call with appropriate exponential backoff.
     package func watch<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Health_V1_HealthCheckRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Health_V1_HealthCheckRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Health_V1_HealthCheckRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Health_V1_HealthCheckResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Health_V1_HealthCheckResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,

--- a/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
@@ -44,13 +44,13 @@ public struct ClientTracingInterceptor: ClientInterceptor {
   /// Which key-value pairs are injected will depend on the specific tracing implementation
   /// that has been configured when bootstrapping `swift-distributed-tracing` in your application.
   public func intercept<Input, Output>(
-    request: ClientRequest.Stream<Input>,
+    request: StreamingClientRequest<Input>,
     context: ClientContext,
     next: (
-      ClientRequest.Stream<Input>,
+      StreamingClientRequest<Input>,
       ClientContext
-    ) async throws -> ClientResponse.Stream<Output>
-  ) async throws -> ClientResponse.Stream<Output> where Input: Sendable, Output: Sendable {
+    ) async throws -> StreamingClientResponse<Output>
+  ) async throws -> StreamingClientResponse<Output> where Input: Sendable, Output: Sendable {
     var request = request
     let tracer = InstrumentationSystem.tracer
     let serviceContext = ServiceContext.current ?? .topLevel
@@ -92,7 +92,7 @@ public struct ClientTracingInterceptor: ClientInterceptor {
         }
       }
 
-      var response: ClientResponse.Stream<Output>
+      var response: StreamingClientResponse<Output>
       do {
         response = try await next(request, context)
       } catch {

--- a/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
@@ -43,11 +43,11 @@ public struct ServerTracingInterceptor: ServerInterceptor {
   /// Which key-value pairs are extracted and made available will depend on the specific tracing implementation
   /// that has been configured when bootstrapping `swift-distributed-tracing` in your application.
   public func intercept<Input, Output>(
-    request: ServerRequest.Stream<Input>,
+    request: StreamingServerRequest<Input>,
     context: ServerContext,
-    next: @Sendable (ServerRequest.Stream<Input>, ServerContext) async throws ->
-      ServerResponse.Stream<Output>
-  ) async throws -> ServerResponse.Stream<Output> where Input: Sendable, Output: Sendable {
+    next: @Sendable (StreamingServerRequest<Input>, ServerContext) async throws ->
+      StreamingServerResponse<Output>
+  ) async throws -> StreamingServerResponse<Output> where Input: Sendable, Output: Sendable {
     var serviceContext = ServiceContext.topLevel
     let tracer = InstrumentationSystem.tracer
 

--- a/Sources/GRPCInteropTests/Generated/empty_service.grpc.swift
+++ b/Sources/GRPCInteropTests/Generated/empty_service.grpc.swift
@@ -30,13 +30,13 @@ public enum Grpc_Testing_EmptyService {
         public static let descriptors: [GRPCCore.MethodDescriptor] = []
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias StreamingServiceProtocol = Grpc_Testing_EmptyServiceStreamingServiceProtocol
+    public typealias StreamingServiceProtocol = Grpc_Testing_EmptyService_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ServiceProtocol = Grpc_Testing_EmptyServiceServiceProtocol
+    public typealias ServiceProtocol = Grpc_Testing_EmptyService_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ClientProtocol = Grpc_Testing_EmptyServiceClientProtocol
+    public typealias ClientProtocol = Grpc_Testing_EmptyService_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias Client = Grpc_Testing_EmptyServiceClient
+    public typealias Client = Grpc_Testing_EmptyService_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -49,7 +49,7 @@ extension GRPCCore.ServiceDescriptor {
 /// A service that has zero methods.
 /// See https://github.com/grpc/grpc/issues/15574
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_EmptyServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
+public protocol Grpc_Testing_EmptyService_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {}
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
@@ -61,9 +61,9 @@ extension Grpc_Testing_EmptyService.StreamingServiceProtocol {
 /// A service that has zero methods.
 /// See https://github.com/grpc/grpc/issues/15574
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_EmptyServiceServiceProtocol: Grpc_Testing_EmptyService.StreamingServiceProtocol {}
+public protocol Grpc_Testing_EmptyService_ServiceProtocol: Grpc_Testing_EmptyService.StreamingServiceProtocol {}
 
-/// Partial conformance to `Grpc_Testing_EmptyServiceStreamingServiceProtocol`.
+/// Partial conformance to `Grpc_Testing_EmptyService_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.ServiceProtocol {
 }
@@ -71,7 +71,7 @@ extension Grpc_Testing_EmptyService.ServiceProtocol {
 /// A service that has zero methods.
 /// See https://github.com/grpc/grpc/issues/15574
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_EmptyServiceClientProtocol: Sendable {}
+public protocol Grpc_Testing_EmptyService_ClientProtocol: Sendable {}
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.ClientProtocol {
@@ -84,7 +84,7 @@ extension Grpc_Testing_EmptyService.ClientProtocol {
 /// A service that has zero methods.
 /// See https://github.com/grpc/grpc/issues/15574
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public struct Grpc_Testing_EmptyServiceClient: Grpc_Testing_EmptyService.ClientProtocol {
+public struct Grpc_Testing_EmptyService_Client: Grpc_Testing_EmptyService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     public init(wrapping client: GRPCCore.GRPCClient) {

--- a/Sources/GRPCInteropTests/Generated/test.grpc.swift
+++ b/Sources/GRPCInteropTests/Generated/test.grpc.swift
@@ -52,13 +52,13 @@ public enum Grpc_Testing_ReconnectService {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias StreamingServiceProtocol = Grpc_Testing_ReconnectServiceStreamingServiceProtocol
+    public typealias StreamingServiceProtocol = Grpc_Testing_ReconnectService_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ServiceProtocol = Grpc_Testing_ReconnectServiceServiceProtocol
+    public typealias ServiceProtocol = Grpc_Testing_ReconnectService_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ClientProtocol = Grpc_Testing_ReconnectServiceClientProtocol
+    public typealias ClientProtocol = Grpc_Testing_ReconnectService_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias Client = Grpc_Testing_ReconnectServiceClient
+    public typealias Client = Grpc_Testing_ReconnectService_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -147,13 +147,13 @@ public enum Grpc_Testing_TestService {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias StreamingServiceProtocol = Grpc_Testing_TestServiceStreamingServiceProtocol
+    public typealias StreamingServiceProtocol = Grpc_Testing_TestService_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ServiceProtocol = Grpc_Testing_TestServiceServiceProtocol
+    public typealias ServiceProtocol = Grpc_Testing_TestService_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ClientProtocol = Grpc_Testing_TestServiceClientProtocol
+    public typealias ClientProtocol = Grpc_Testing_TestService_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias Client = Grpc_Testing_TestServiceClient
+    public typealias Client = Grpc_Testing_TestService_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -179,13 +179,13 @@ public enum Grpc_Testing_UnimplementedService {
         ]
     }
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias StreamingServiceProtocol = Grpc_Testing_UnimplementedServiceStreamingServiceProtocol
+    public typealias StreamingServiceProtocol = Grpc_Testing_UnimplementedService_StreamingServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ServiceProtocol = Grpc_Testing_UnimplementedServiceServiceProtocol
+    public typealias ServiceProtocol = Grpc_Testing_UnimplementedService_ServiceProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias ClientProtocol = Grpc_Testing_UnimplementedServiceClientProtocol
+    public typealias ClientProtocol = Grpc_Testing_UnimplementedService_ClientProtocol
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-    public typealias Client = Grpc_Testing_UnimplementedServiceClient
+    public typealias Client = Grpc_Testing_UnimplementedService_Client
 }
 
 extension GRPCCore.ServiceDescriptor {
@@ -198,64 +198,64 @@ extension GRPCCore.ServiceDescriptor {
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_TestServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+public protocol Grpc_Testing_TestService_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// One empty request followed by one empty response.
     func emptyCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty>
     
     /// One request followed by one response.
     func unaryCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_SimpleRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_SimpleResponse>
     
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     func cacheableUnaryCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_SimpleRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_SimpleResponse>
     
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     func streamingOutputCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse>
     
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     func streamingInputCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingInputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingInputCallResponse>
     
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     func fullDuplexCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse>
     
     /// A sequence of requests followed by a sequence of responses.
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     func halfDuplexCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse>
     
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     func unimplementedCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -357,145 +357,145 @@ extension Grpc_Testing_TestService.StreamingServiceProtocol {
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_TestServiceServiceProtocol: Grpc_Testing_TestService.StreamingServiceProtocol {
+public protocol Grpc_Testing_TestService_ServiceProtocol: Grpc_Testing_TestService.StreamingServiceProtocol {
     /// One empty request followed by one empty response.
     func emptyCall(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_Empty>
     
     /// One request followed by one response.
     func unaryCall(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_SimpleRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_SimpleResponse>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_SimpleResponse>
     
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     func cacheableUnaryCall(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_SimpleRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_SimpleResponse>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_SimpleResponse>
     
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     func streamingOutputCall(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse>
     
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     func streamingInputCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingInputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_StreamingInputCallResponse>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_StreamingInputCallResponse>
     
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     func fullDuplexCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse>
     
     /// A sequence of requests followed by a sequence of responses.
     /// The server buffers all the client requests and then serves them in order. A
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     func halfDuplexCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse>
     
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     func unimplementedCall(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_Empty>
 }
 
-/// Partial conformance to `Grpc_Testing_TestServiceStreamingServiceProtocol`.
+/// Partial conformance to `Grpc_Testing_TestService_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ServiceProtocol {
     public func emptyCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty> {
         let response = try await self.emptyCall(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
     
     public func unaryCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_SimpleRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_SimpleResponse> {
         let response = try await self.unaryCall(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
     
     public func cacheableUnaryCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_SimpleRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_SimpleResponse> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_SimpleResponse> {
         let response = try await self.cacheableUnaryCall(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
     
     public func streamingOutputCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse> {
         let response = try await self.streamingOutputCall(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
         return response
     }
     
     public func streamingInputCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_StreamingInputCallRequest>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_StreamingInputCallResponse> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_StreamingInputCallResponse> {
         let response = try await self.streamingInputCall(
             request: request,
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
     
     public func unimplementedCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty> {
         let response = try await self.unimplementedCall(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
 }
 
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_UnimplementedServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+public protocol Grpc_Testing_UnimplementedService_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     /// A call that no server should implement
     func unimplementedCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -520,41 +520,41 @@ extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_UnimplementedServiceServiceProtocol: Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
+public protocol Grpc_Testing_UnimplementedService_ServiceProtocol: Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
     /// A call that no server should implement
     func unimplementedCall(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_Empty>
 }
 
-/// Partial conformance to `Grpc_Testing_UnimplementedServiceStreamingServiceProtocol`.
+/// Partial conformance to `Grpc_Testing_UnimplementedService_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ServiceProtocol {
     public func unimplementedCall(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty> {
         let response = try await self.unimplementedCall(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
 }
 
 /// A service used to control reconnect server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_ReconnectServiceStreamingServiceProtocol: GRPCCore.RegistrableRPCService {
+public protocol Grpc_Testing_ReconnectService_StreamingServiceProtocol: GRPCCore.RegistrableRPCService {
     func start(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ReconnectParams>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_ReconnectParams>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty>
     
     func stop(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ReconnectInfo>
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_ReconnectInfo>
 }
 
 /// Conformance to `GRPCCore.RegistrableRPCService`.
@@ -589,106 +589,106 @@ extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
 
 /// A service used to control reconnect server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_ReconnectServiceServiceProtocol: Grpc_Testing_ReconnectService.StreamingServiceProtocol {
+public protocol Grpc_Testing_ReconnectService_ServiceProtocol: Grpc_Testing_ReconnectService.StreamingServiceProtocol {
     func start(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_ReconnectParams>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_ReconnectParams>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_Empty>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_Empty>
     
     func stop(
-        request: GRPCCore.ServerRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Single<Grpc_Testing_ReconnectInfo>
+    ) async throws -> GRPCCore.ServerResponse<Grpc_Testing_ReconnectInfo>
 }
 
-/// Partial conformance to `Grpc_Testing_ReconnectServiceStreamingServiceProtocol`.
+/// Partial conformance to `Grpc_Testing_ReconnectService_StreamingServiceProtocol`.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ServiceProtocol {
     public func start(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_ReconnectParams>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_ReconnectParams>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_Empty> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_Empty> {
         let response = try await self.start(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
     
     public func stop(
-        request: GRPCCore.ServerRequest.Stream<Grpc_Testing_Empty>,
+        request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
         context: GRPCCore.ServerContext
-    ) async throws -> GRPCCore.ServerResponse.Stream<Grpc_Testing_ReconnectInfo> {
+    ) async throws -> GRPCCore.StreamingServerResponse<Grpc_Testing_ReconnectInfo> {
         let response = try await self.stop(
-            request: GRPCCore.ServerRequest.Single(stream: request),
+            request: GRPCCore.ServerRequest(stream: request),
             context: context
         )
-        return GRPCCore.ServerResponse.Stream(single: response)
+        return GRPCCore.StreamingServerResponse(single: response)
     }
 }
 
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_TestServiceClientProtocol: Sendable {
+public protocol Grpc_Testing_TestService_ClientProtocol: Sendable {
     /// One empty request followed by one empty response.
     func emptyCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// One request followed by one response.
     func unaryCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// One request followed by one response. Response has cache control
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     func cacheableUnaryCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     func streamingOutputCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     func streamingInputCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingInputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_StreamingInputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// A sequence of requests with each request served by the server immediately.
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     func fullDuplexCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// A sequence of requests followed by a sequence of responses.
@@ -696,30 +696,30 @@ public protocol Grpc_Testing_TestServiceClientProtocol: Sendable {
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     func halfDuplexCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable
     
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     func unimplementedCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ClientProtocol {
     public func emptyCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -733,9 +733,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func unaryCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -749,9 +749,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func cacheableUnaryCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -765,9 +765,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func streamingOutputCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.streamingOutputCall(
             request: request,
@@ -779,9 +779,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func streamingInputCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingInputCallRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_StreamingInputCallResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -795,9 +795,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func fullDuplexCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.fullDuplexCall(
             request: request,
@@ -809,9 +809,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func halfDuplexCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.halfDuplexCall(
             request: request,
@@ -823,9 +823,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
     }
     
     public func unimplementedCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -846,11 +846,11 @@ extension Grpc_Testing_TestService.ClientProtocol {
         _ message: Grpc_Testing_Empty,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_Empty>(
             message: message,
             metadata: metadata
         )
@@ -866,11 +866,11 @@ extension Grpc_Testing_TestService.ClientProtocol {
         _ message: Grpc_Testing_SimpleRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>(
             message: message,
             metadata: metadata
         )
@@ -888,11 +888,11 @@ extension Grpc_Testing_TestService.ClientProtocol {
         _ message: Grpc_Testing_SimpleRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>(
             message: message,
             metadata: metadata
         )
@@ -909,9 +909,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
         _ message: Grpc_Testing_StreamingOutputCallRequest,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> Result
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_StreamingOutputCallRequest>(
             message: message,
             metadata: metadata
         )
@@ -928,11 +928,11 @@ extension Grpc_Testing_TestService.ClientProtocol {
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
         requestProducer: @Sendable @escaping (GRPCCore.RPCWriter<Grpc_Testing_StreamingInputCallRequest>) async throws -> Void,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_StreamingInputCallResponse>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>(
+        let request = GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingInputCallRequest>(
             metadata: metadata,
             producer: requestProducer
         )
@@ -950,9 +950,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
         requestProducer: @Sendable @escaping (GRPCCore.RPCWriter<Grpc_Testing_StreamingOutputCallRequest>) async throws -> Void,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> Result
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>(
+        let request = GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>(
             metadata: metadata,
             producer: requestProducer
         )
@@ -971,9 +971,9 @@ extension Grpc_Testing_TestService.ClientProtocol {
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
         requestProducer: @Sendable @escaping (GRPCCore.RPCWriter<Grpc_Testing_StreamingOutputCallRequest>) async throws -> Void,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> Result
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> Result
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>(
+        let request = GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>(
             metadata: metadata,
             producer: requestProducer
         )
@@ -990,11 +990,11 @@ extension Grpc_Testing_TestService.ClientProtocol {
         _ message: Grpc_Testing_Empty,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_Empty>(
             message: message,
             metadata: metadata
         )
@@ -1009,7 +1009,7 @@ extension Grpc_Testing_TestService.ClientProtocol {
 /// A simple service to test the various types of RPCs and experiment with
 /// performance with various types of payload.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientProtocol {
+public struct Grpc_Testing_TestService_Client: Grpc_Testing_TestService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     public init(wrapping client: GRPCCore.GRPCClient) {
@@ -1018,11 +1018,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     
     /// One empty request followed by one empty response.
     public func emptyCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1038,11 +1038,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     
     /// One request followed by one response.
     public func unaryCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1060,11 +1060,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// headers set such that a caching HTTP proxy (such as GFE) can
     /// satisfy subsequent requests.
     public func cacheableUnaryCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_SimpleRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_SimpleRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_SimpleRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_SimpleResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_SimpleResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_SimpleResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1081,11 +1081,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// One request followed by a sequence of responses (streamed download).
     /// The server returns the payload with client desired type and sizes.
     public func streamingOutputCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.serverStreaming(
             request: request,
@@ -1100,11 +1100,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// A sequence of requests followed by one response (streamed upload).
     /// The server returns the aggregated size of client payload as the result.
     public func streamingInputCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingInputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingInputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingInputCallResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_StreamingInputCallResponse>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_StreamingInputCallResponse>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1122,11 +1122,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// As one request could lead to multiple responses, this interface
     /// demonstrates the idea of full duplexing.
     public func fullDuplexCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -1143,11 +1143,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// stream of responses are returned to the client when the server starts with
     /// first request.
     public func halfDuplexCall<R>(
-        request: GRPCCore.ClientRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+        request: GRPCCore.StreamingClientRequest<Grpc_Testing_StreamingOutputCallRequest>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_StreamingOutputCallRequest>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_StreamingOutputCallResponse>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Stream<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.StreamingClientResponse<Grpc_Testing_StreamingOutputCallResponse>) async throws -> R
     ) async throws -> R where R: Sendable {
         try await self.client.bidirectionalStreaming(
             request: request,
@@ -1162,11 +1162,11 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
     /// The test server will not implement this method. It will be used
     /// to test the behavior when clients call unimplemented methods.
     public func unimplementedCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1184,23 +1184,23 @@ public struct Grpc_Testing_TestServiceClient: Grpc_Testing_TestService.ClientPro
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_UnimplementedServiceClientProtocol: Sendable {
+public protocol Grpc_Testing_UnimplementedService_ClientProtocol: Sendable {
     /// A call that no server should implement
     func unimplementedCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ClientProtocol {
     public func unimplementedCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1221,11 +1221,11 @@ extension Grpc_Testing_UnimplementedService.ClientProtocol {
         _ message: Grpc_Testing_Empty,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_Empty>(
             message: message,
             metadata: metadata
         )
@@ -1240,7 +1240,7 @@ extension Grpc_Testing_UnimplementedService.ClientProtocol {
 /// A simple service NOT implemented at servers so clients can test for
 /// that case.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_UnimplementedService.ClientProtocol {
+public struct Grpc_Testing_UnimplementedService_Client: Grpc_Testing_UnimplementedService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     public init(wrapping client: GRPCCore.GRPCClient) {
@@ -1249,11 +1249,11 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
     
     /// A call that no server should implement
     public func unimplementedCall<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1270,30 +1270,30 @@ public struct Grpc_Testing_UnimplementedServiceClient: Grpc_Testing_Unimplemente
 
 /// A service used to control reconnect server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public protocol Grpc_Testing_ReconnectServiceClientProtocol: Sendable {
+public protocol Grpc_Testing_ReconnectService_ClientProtocol: Sendable {
     func start<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_ReconnectParams>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_ReconnectParams>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R
     ) async throws -> R where R: Sendable
     
     func stop<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_ReconnectInfo>,
         options: GRPCCore.CallOptions,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_ReconnectInfo>) async throws -> R
     ) async throws -> R where R: Sendable
 }
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ClientProtocol {
     public func start<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_ReconnectParams>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1307,9 +1307,9 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
     }
     
     public func stop<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_ReconnectInfo>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1329,11 +1329,11 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
         _ message: Grpc_Testing_ReconnectParams,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_ReconnectParams>(
             message: message,
             metadata: metadata
         )
@@ -1348,11 +1348,11 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
         _ message: Grpc_Testing_Empty,
         metadata: GRPCCore.Metadata = [:],
         options: GRPCCore.CallOptions = .defaults,
-        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> Result = {
+        onResponse handleResponse: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_ReconnectInfo>) async throws -> Result = {
             try $0.message
         }
     ) async throws -> Result where Result: Sendable {
-        let request = GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>(
+        let request = GRPCCore.ClientRequest<Grpc_Testing_Empty>(
             message: message,
             metadata: metadata
         )
@@ -1366,7 +1366,7 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
 
 /// A service used to control reconnect server.
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService.ClientProtocol {
+public struct Grpc_Testing_ReconnectService_Client: Grpc_Testing_ReconnectService.ClientProtocol {
     private let client: GRPCCore.GRPCClient
     
     public init(wrapping client: GRPCCore.GRPCClient) {
@@ -1374,11 +1374,11 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
     }
     
     public func start<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_ReconnectParams>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_ReconnectParams>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_ReconnectParams>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_Empty>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_Empty>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_Empty>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {
@@ -1393,11 +1393,11 @@ public struct Grpc_Testing_ReconnectServiceClient: Grpc_Testing_ReconnectService
     }
     
     public func stop<R>(
-        request: GRPCCore.ClientRequest.Single<Grpc_Testing_Empty>,
+        request: GRPCCore.ClientRequest<Grpc_Testing_Empty>,
         serializer: some GRPCCore.MessageSerializer<Grpc_Testing_Empty>,
         deserializer: some GRPCCore.MessageDeserializer<Grpc_Testing_ReconnectInfo>,
         options: GRPCCore.CallOptions = .defaults,
-        _ body: @Sendable @escaping (GRPCCore.ClientResponse.Single<Grpc_Testing_ReconnectInfo>) async throws -> R = {
+        _ body: @Sendable @escaping (GRPCCore.ClientResponse<Grpc_Testing_ReconnectInfo>) async throws -> R = {
             try $0.message
         }
     ) async throws -> R where R: Sendable {

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -22,20 +22,20 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}
 
   public func unimplementedCall(
-    request: ServerRequest.Single<Grpc_Testing_Empty>,
+    request: ServerRequest<Grpc_Testing_Empty>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Grpc_Testing_Empty> {
+  ) async throws -> ServerResponse<Grpc_Testing_Empty> {
     throw RPCError(code: .unimplemented, message: "The RPC is not implemented.")
   }
 
   /// Server implements `emptyCall` which immediately returns the empty message.
   public func emptyCall(
-    request: ServerRequest.Single<Grpc_Testing_Empty>,
+    request: ServerRequest<Grpc_Testing_Empty>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Grpc_Testing_Empty> {
+  ) async throws -> ServerResponse<Grpc_Testing_Empty> {
     let message = Grpc_Testing_Empty()
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
-    return ServerResponse.Single(
+    return ServerResponse(
       message: message,
       metadata: initialMetadata,
       trailingMetadata: trailingMetadata
@@ -49,9 +49,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// If the server does not support the `responseType`, then it should fail the RPC with
   /// `INVALID_ARGUMENT`.
   public func unaryCall(
-    request: ServerRequest.Single<Grpc_Testing_SimpleRequest>,
+    request: ServerRequest<Grpc_Testing_SimpleRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse> {
+  ) async throws -> ServerResponse<Grpc_Testing_SimpleResponse> {
     // We can't validate messages at the wire-encoding layer (i.e. where the compression byte is
     // set), so we have to check via the encoding header. Note that it is possible for the header
     // to be set and for the message to not be compressed.
@@ -94,7 +94,7 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
 
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
 
-    return ServerResponse.Single(
+    return ServerResponse(
       message: responseMessage,
       metadata: initialMetadata,
       trailingMetadata: trailingMetadata
@@ -109,9 +109,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// headers such that the response can be cached by proxies in the response path. Server should
   /// be behind a caching proxy for this test to pass. Currently we set the max-age to 60 seconds.
   public func cacheableUnaryCall(
-    request: ServerRequest.Single<Grpc_Testing_SimpleRequest>,
+    request: ServerRequest<Grpc_Testing_SimpleRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Grpc_Testing_SimpleResponse> {
+  ) async throws -> ServerResponse<Grpc_Testing_SimpleResponse> {
     throw RPCError(code: .unimplemented, message: "The RPC is not implemented.")
   }
 
@@ -121,11 +121,11 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// bytes, as specified by its respective `ResponseParameter`. After sending all responses, it
   /// closes with OK.
   public func streamingOutputCall(
-    request: ServerRequest.Single<Grpc_Testing_StreamingOutputCallRequest>,
+    request: ServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
+  ) async throws -> StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse> {
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
-    return ServerResponse.Stream(metadata: initialMetadata) { writer in
+    return StreamingServerResponse(metadata: initialMetadata) { writer in
       for responseParameter in request.message.responseParameters {
         let response = Grpc_Testing_StreamingOutputCallResponse.with { response in
           response.payload = Grpc_Testing_Payload.with { payload in
@@ -144,9 +144,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// `StreamingInputCallResponse` where `aggregatedPayloadSize` is the sum of all request payload
   /// bodies received.
   public func streamingInputCall(
-    request: ServerRequest.Stream<Grpc_Testing_StreamingInputCallRequest>,
+    request: StreamingServerRequest<Grpc_Testing_StreamingInputCallRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Single<Grpc_Testing_StreamingInputCallResponse> {
+  ) async throws -> ServerResponse<Grpc_Testing_StreamingInputCallResponse> {
     let isRequestCompressed =
       request.metadata["grpc-encoding"].filter({ $0 != "identity" }).count > 0
     var aggregatedPayloadSize = 0
@@ -170,7 +170,7 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
     }
 
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
-    return ServerResponse.Single(
+    return ServerResponse(
       message: responseMessage,
       metadata: initialMetadata,
       trailingMetadata: trailingMetadata
@@ -183,11 +183,11 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   /// of size `ResponseParameter.size` bytes, as specified by its respective `ResponseParameter`s.
   /// After receiving half close and sending all responses, it closes with OK.
   public func fullDuplexCall(
-    request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+    request: StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
+  ) async throws -> StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse> {
     let (initialMetadata, trailingMetadata) = request.metadata.makeInitialAndTrailingMetadata()
-    return ServerResponse.Stream(metadata: initialMetadata) { writer in
+    return StreamingServerResponse(metadata: initialMetadata) { writer in
       for try await message in request.messages {
         // If a request message has a responseStatus set, the server should return that status.
         // If the code is an error code, the server will throw an error containing that code
@@ -221,9 +221,9 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   ///
   /// See: https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md
   public func halfDuplexCall(
-    request: ServerRequest.Stream<Grpc_Testing_StreamingOutputCallRequest>,
+    request: StreamingServerRequest<Grpc_Testing_StreamingOutputCallRequest>,
     context: ServerContext
-  ) async throws -> ServerResponse.Stream<Grpc_Testing_StreamingOutputCallResponse> {
+  ) async throws -> StreamingServerResponse<Grpc_Testing_StreamingOutputCallResponse> {
     throw RPCError(code: .unimplemented, message: "The RPC is not implemented.")
   }
 }

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -56,7 +56,7 @@ final class TracingInterceptorTests: XCTestCase {
         return .init(
           metadata: [],
           bodyParts: RPCAsyncSequence(
-            wrapping: AsyncThrowingStream<ClientResponse.Stream.Contents.BodyPart, any Error> {
+            wrapping: AsyncThrowingStream<StreamingClientResponse.Contents.BodyPart, any Error> {
               $0.yield(.message(["response"]))
               $0.finish()
             }
@@ -121,7 +121,7 @@ final class TracingInterceptorTests: XCTestCase {
         return .init(
           metadata: [],
           bodyParts: RPCAsyncSequence(
-            wrapping: AsyncThrowingStream<ClientResponse.Stream.Contents.BodyPart, any Error> {
+            wrapping: AsyncThrowingStream<StreamingClientResponse.Contents.BodyPart, any Error> {
               $0.yield(.message(["response"]))
               $0.finish()
             }
@@ -173,12 +173,12 @@ final class TracingInterceptorTests: XCTestCase {
       method: "testServerInterceptorErrorResponse"
     )
     let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: false)
-    let single = ServerRequest.Single(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
+    let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
       request: .init(single: single),
       context: .init(descriptor: methodDescriptor)
     ) { _, _ in
-      ServerResponse.Stream<String>(error: .init(code: .unknown, message: "Test error"))
+      StreamingServerResponse<String>(error: .init(code: .unknown, message: "Test error"))
     }
     XCTAssertThrowsError(try response.accepted.get())
 
@@ -202,13 +202,13 @@ final class TracingInterceptorTests: XCTestCase {
     )
     let (stream, continuation) = AsyncStream<String>.makeStream()
     let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: false)
-    let single = ServerRequest.Single(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
+    let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
       request: .init(single: single),
       context: .init(descriptor: methodDescriptor)
     ) { _, _ in
       { [serviceContext = ServiceContext.current] in
-        return ServerResponse.Stream<String>(
+        return StreamingServerResponse<String>(
           accepted: .success(
             .init(
               metadata: [],
@@ -267,13 +267,13 @@ final class TracingInterceptorTests: XCTestCase {
     )
     let (stream, continuation) = AsyncStream<String>.makeStream()
     let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: true)
-    let single = ServerRequest.Single(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
+    let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
       request: .init(single: single),
       context: .init(descriptor: methodDescriptor)
     ) { _, _ in
       { [serviceContext = ServiceContext.current] in
-        return ServerResponse.Stream<String>(
+        return StreamingServerResponse<String>(
           accepted: .success(
             .init(
               metadata: [],

--- a/Tests/InProcessInteropTests/InProcessInteroperabilityTests.swift
+++ b/Tests/InProcessInteropTests/InProcessInteroperabilityTests.swift
@@ -25,7 +25,7 @@ final class InProcessInteroperabilityTests: XCTestCase {
     interopTestCase: InteroperabilityTestCase
   ) async throws {
     do {
-      let inProcess = InProcessTransport.makePair()
+      let inProcess = InProcessTransport()
       try await withThrowingTaskGroup(of: Void.self) { group in
         group.addTask {
           let server = GRPCServer(transport: inProcess.server, services: [TestService()])


### PR DESCRIPTION
Motivation:

Some names were changed in https://github.com/grpc/grpc-swift/pull/2076 which we need to update here.

Modifications:

- Update names of request/response types
- Regenerate code

Result:

Compiles