### PR TITLE
Add deployment targets to the package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -116,6 +116,13 @@ let targets: [Target] = [
 
 let package = Package(
   name: "grpc-swift-extras",
+  platforms: [
+    .macOS(.v15),
+    .iOS(.v18),
+    .tvOS(.v18),
+    .watchOS(.v11),
+    .visionOS(.v2),
+  ],
   products: products,
   dependencies: dependencies,
   targets: targets

--- a/Sources/GRPCHealthService/Health.swift
+++ b/Sources/GRPCHealthService/Health.swift
@@ -40,7 +40,6 @@ public import GRPCCore
 ///   forService: .bar_Foo
 /// )
 /// ```
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct Health: Sendable {
   /// An implementation of the `grpc.health.v1.Health` service.
   public let service: Health.Service
@@ -58,7 +57,6 @@ public struct Health: Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Health {
   /// An implementation of the `grpc.health.v1.Health` service.
   public struct Service: RegistrableRPCService, Sendable {

--- a/Sources/GRPCHealthService/HealthService.swift
+++ b/Sources/GRPCHealthService/HealthService.swift
@@ -17,7 +17,6 @@
 internal import GRPCCore
 private import Synchronization
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 internal struct HealthService: Grpc_Health_V1_Health_ServiceProtocol {
   private let state = HealthService.State()
 
@@ -66,7 +65,6 @@ internal struct HealthService: Grpc_Health_V1_Health_ServiceProtocol {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension HealthService {
   private final class State: Sendable {
     // The state of each service keyed by the fully qualified service name.

--- a/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ClientTracingInterceptor.swift
@@ -23,7 +23,6 @@ internal import Tracing
 /// metadata. It will then be picked up by the server-side ``ServerTracingInterceptor``.
 ///
 /// For more information, refer to the documentation for `swift-distributed-tracing`.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct ClientTracingInterceptor: ClientInterceptor {
   private let injector: ClientRequestInjector
   private let emitEventOnEachWrite: Bool
@@ -132,7 +131,6 @@ public struct ClientTracingInterceptor: ClientInterceptor {
 
 /// An injector responsible for injecting the required instrumentation keys from the `ServiceContext` into
 /// the request metadata.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ClientRequestInjector: Instrumentation.Injector {
   typealias Carrier = Metadata
 

--- a/Sources/GRPCInterceptors/HookedWriter.swift
+++ b/Sources/GRPCInterceptors/HookedWriter.swift
@@ -16,7 +16,6 @@
 internal import GRPCCore
 internal import Tracing
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct HookedWriter<Element: Sendable>: RPCWriterProtocol {
   private let writer: any RPCWriterProtocol<Element>
   private let beforeEachWrite: @Sendable () -> Void

--- a/Sources/GRPCInterceptors/OnFinishAsyncSequence.swift
+++ b/Sources/GRPCInterceptors/OnFinishAsyncSequence.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct OnFinishAsyncSequence<Element: Sendable>: AsyncSequence, Sendable {
   private let _makeAsyncIterator: @Sendable () -> AsyncIterator
 

--- a/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
@@ -21,7 +21,6 @@ internal import Tracing
 ///
 /// The extracted tracing information is made available to user code via the current `ServiceContext`.
 /// For more information, refer to the documentation for `swift-distributed-tracing`.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct ServerTracingInterceptor: ServerInterceptor {
   private let extractor: ServerRequestExtractor
   private let emitEventOnEachWrite: Bool
@@ -136,7 +135,6 @@ public struct ServerTracingInterceptor: ServerInterceptor {
 }
 
 /// An extractor responsible for extracting the required instrumentation keys from request metadata.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ServerRequestExtractor: Instrumentation.Extractor {
   typealias Carrier = Metadata
 

--- a/Sources/GRPCInteropTests/InteroperabilityTestCase.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCase.swift
@@ -15,7 +15,6 @@
  */
 public import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public protocol InteroperabilityTest {
   /// Run a test case using the given connection.
   ///
@@ -69,7 +68,6 @@ public enum InteroperabilityTestCase: String, CaseIterable, Sendable {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension InteroperabilityTestCase {
   /// Return a new instance of the test case.
   public func makeTest() -> any InteroperabilityTest {

--- a/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
@@ -31,7 +31,6 @@ private import struct Foundation.Data
 /// Client asserts:
 /// - call was successful
 /// - response is non-null
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct EmptyUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -65,7 +64,6 @@ struct EmptyUnary: InteroperabilityTest {
 /// - response payload body is 314159 bytes in size
 /// - clients are free to assert that the response payload body contents are zero and comparing
 ///   the entire response message against a golden response
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct LargeUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -141,7 +139,6 @@ struct LargeUnary: InteroperabilityTest {
 /// - Response payload body is 314159 bytes in size.
 /// - Clients are free to assert that the response payload body contents are zeros and comparing the
 ///   entire response message against a golden response.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 class ClientCompressedUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -250,7 +247,6 @@ class ClientCompressedUnary: InteroperabilityTest {
 /// - response payload body is 314159 bytes in size in both cases.
 /// - clients are free to assert that the response payload body contents are zero and comparing the
 ///   entire response message against a golden response
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 class ServerCompressedUnary: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -340,7 +336,6 @@ class ServerCompressedUnary: InteroperabilityTest {
 /// Client asserts:
 /// - call was successful
 /// - response aggregated_payload_size is 74922
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ClientStreaming: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -391,7 +386,6 @@ struct ClientStreaming: InteroperabilityTest {
 /// - response payload bodies are sized (in order): 31415, 9, 2653, 58979
 /// - clients are free to assert that the response payload body contents are zero and
 ///   comparing the entire response messages against golden responses
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct ServerStreaming: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -468,7 +462,6 @@ struct ServerStreaming: InteroperabilityTest {
 /// - clients are free to assert that the response payload body contents are zero and comparing the
 ///   entire response messages against golden responses
 class ServerCompressedStreaming: InteroperabilityTest {
-  @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
     let request: Grpc_Testing_StreamingOutputCallRequest = .with { request in
@@ -580,7 +573,6 @@ class ServerCompressedStreaming: InteroperabilityTest {
 /// - response payload bodies are sized (in order): 31415, 9, 2653, 58979
 /// - clients are free to assert that the response payload body contents are zero and
 ///   comparing the entire response messages against golden responses
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct PingPong: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -647,7 +639,6 @@ struct PingPong: InteroperabilityTest {
 /// Client asserts:
 /// - call was successful
 /// - exactly zero responses
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct EmptyStream: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -703,7 +694,6 @@ struct EmptyStream: InteroperabilityTest {
 ///   received in the initial metadata for calls in Procedure steps 1 and 2.
 /// - metadata with key "x-grpc-test-echo-trailing-bin" and value 0xababab is received in the
 ///   trailing metadata for calls in Procedure steps 1 and 2.
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct CustomMetadata: InteroperabilityTest {
   let initialMetadataName = "x-grpc-test-echo-initial"
   let initialMetadataValue = "test_initial_metadata_value"
@@ -824,7 +814,6 @@ struct CustomMetadata: InteroperabilityTest {
 /// Client asserts:
 /// - received status code is the same as the sent code for both Procedure steps 1 and 2
 /// - received status message is the same as the sent message for both Procedure steps 1 and 2
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct StatusCodeAndMessage: InteroperabilityTest {
   let expectedCode = 2
   let expectedMessage = "test status message"
@@ -902,7 +891,6 @@ struct StatusCodeAndMessage: InteroperabilityTest {
 /// - received status code is the same as the sent code for Procedure step 1
 /// - received status message is the same as the sent message for Procedure step 1, including all
 ///   whitespace characters
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct SpecialStatusMessage: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -945,7 +933,6 @@ struct SpecialStatusMessage: InteroperabilityTest {
 ///
 /// Client asserts:
 /// - received status code is 12 (UNIMPLEMENTED)
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct UnimplementedMethod: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -978,7 +965,6 @@ struct UnimplementedMethod: InteroperabilityTest {
 ///
 /// Client asserts:
 /// - received status code is 12 (UNIMPLEMENTED)
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 struct UnimplementedService: InteroperabilityTest {
   func run(client: GRPCClient) async throws {
     let unimplementedServiceClient = Grpc_Testing_UnimplementedService.Client(wrapping: client)

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -17,7 +17,6 @@
 private import Foundation
 public import GRPCCore
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}
 

--- a/Sources/GRPCReflectionService/Server/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionService.swift
@@ -19,7 +19,6 @@ import Foundation
 import GRPC
 import SwiftProtobuf
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public final class ReflectionService: CallHandlerProvider, Sendable {
   private let provider: Provider
 
@@ -314,7 +313,6 @@ extension Google_Protobuf_FileDescriptorProto {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ReflectionService {
   /// The version of the reflection service.
   ///
@@ -340,7 +338,6 @@ extension ReflectionService {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension ReflectionService {
   static func readSerializedFileDescriptorProto(
     atPath path: String

--- a/Sources/GRPCReflectionService/Server/ReflectionServiceV1.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionServiceV1.swift
@@ -18,7 +18,6 @@ import Foundation
 import GRPC
 import SwiftProtobuf
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class ReflectionServiceProviderV1: Grpc_Reflection_V1_ServerReflectionAsyncProvider {
   private let protoRegistry: ReflectionServiceData
 

--- a/Sources/GRPCReflectionService/Server/ReflectionServiceV1Alpha.swift
+++ b/Sources/GRPCReflectionService/Server/ReflectionServiceV1Alpha.swift
@@ -18,7 +18,6 @@ import Foundation
 import GRPC
 import SwiftProtobuf
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal final class ReflectionServiceProviderV1Alpha:
   Grpc_Reflection_V1alpha_ServerReflectionAsyncProvider
 {

--- a/Sources/GRPCReflectionService/v1/reflection-v1.grpc.swift
+++ b/Sources/GRPCReflectionService/v1/reflection-v1.grpc.swift
@@ -48,7 +48,6 @@ extension Grpc_Reflection_V1_ServerReflectionProvider {
 }
 
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal protocol Grpc_Reflection_V1_ServerReflectionAsyncProvider: CallHandlerProvider, Sendable {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Reflection_V1_ServerReflectionServerInterceptorFactoryProtocol? { get }
@@ -62,7 +61,6 @@ internal protocol Grpc_Reflection_V1_ServerReflectionAsyncProvider: CallHandlerP
   ) async throws
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Reflection_V1_ServerReflectionAsyncProvider {
   internal static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Reflection_V1_ServerReflectionServerMetadata.serviceDescriptor

--- a/Sources/GRPCReflectionService/v1Alpha/reflection-v1alpha.grpc.swift
+++ b/Sources/GRPCReflectionService/v1Alpha/reflection-v1alpha.grpc.swift
@@ -48,7 +48,6 @@ extension Grpc_Reflection_V1alpha_ServerReflectionProvider {
 }
 
 /// To implement a server, implement an object which conforms to this protocol.
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 internal protocol Grpc_Reflection_V1alpha_ServerReflectionAsyncProvider: CallHandlerProvider, Sendable {
   static var serviceDescriptor: GRPCServiceDescriptor { get }
   var interceptors: Grpc_Reflection_V1alpha_ServerReflectionServerInterceptorFactoryProtocol? { get }
@@ -62,7 +61,6 @@ internal protocol Grpc_Reflection_V1alpha_ServerReflectionAsyncProvider: CallHan
   ) async throws
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Grpc_Reflection_V1alpha_ServerReflectionAsyncProvider {
   internal static var serviceDescriptor: GRPCServiceDescriptor {
     return Grpc_Reflection_V1alpha_ServerReflectionServerMetadata.serviceDescriptor

--- a/Tests/GRPCHealthServiceTests/HealthTests.swift
+++ b/Tests/GRPCHealthServiceTests/HealthTests.swift
@@ -18,7 +18,6 @@ import GRPCHealthService
 import GRPCInProcessTransport
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class HealthTests: XCTestCase {
   private func withHealthClient(
     _ body: @Sendable (Grpc_Health_V1_Health_Client, Health.Provider) async throws -> Void

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -20,7 +20,6 @@ import XCTest
 
 @testable import GRPCInterceptors
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class TracingInterceptorTests: XCTestCase {
   override class func setUp() {
     InstrumentationSystem.bootstrap(TestTracer())

--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -18,7 +18,6 @@ import GRPCCore
 import Synchronization
 import Tracing
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class TestTracer: Tracer {
   typealias Span = TestSpan
 
@@ -69,7 +68,6 @@ final class TestTracer: Tracer {
   }
 }
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class TestSpan: Span, Sendable {
   private struct State {
     var context: ServiceContextModule.ServiceContext
@@ -175,7 +173,6 @@ extension ServiceContext {
   }
 }
 
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct TestWriter<WriterElement: Sendable>: RPCWriterProtocol {
   typealias Element = WriterElement
 

--- a/Tests/InProcessInteropTests/InProcessInteroperabilityTests.swift
+++ b/Tests/InProcessInteropTests/InProcessInteroperabilityTests.swift
@@ -19,7 +19,6 @@ import GRPCInProcessTransport
 import GRPCInteropTests
 import XCTest
 
-@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 final class InProcessInteroperabilityTests: XCTestCase {
   func runInProcessTransport(
     interopTestCase: InteroperabilityTestCase


### PR DESCRIPTION
Motivation:

Core components of grpc-swift v2 require API from the latest SDKs. This causes a proliferation of availability annotations through our API. Rather than doing this we can set the minimum platforms in the package manifest.

Modifications:

- Remove availability annotations
- Set platforms in the package manifest

Result:

- Less boilerplate
- Users must set platforms in their package manifest