### PR TITLE
Depend on `grpc-swift/main`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    exact: "2.0.0-alpha.1"
+    branch: "main"
   ),
   .package(
     url: "https://github.com/grpc/grpc-swift-protobuf.git",

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -175,7 +175,7 @@ final class TracingInterceptorTests: XCTestCase {
     let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
       request: .init(single: single),
-      context: .init(descriptor: methodDescriptor)
+      context: .init(descriptor: methodDescriptor, cancellation: .init())
     ) { _, _ in
       StreamingServerResponse<String>(error: .init(code: .unknown, message: "Test error"))
     }
@@ -204,7 +204,7 @@ final class TracingInterceptorTests: XCTestCase {
     let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
       request: .init(single: single),
-      context: .init(descriptor: methodDescriptor)
+      context: .init(descriptor: methodDescriptor, cancellation: .init())
     ) { _, _ in
       { [serviceContext = ServiceContext.current] in
         return StreamingServerResponse<String>(
@@ -269,7 +269,7 @@ final class TracingInterceptorTests: XCTestCase {
     let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
     let response = try await interceptor.intercept(
       request: .init(single: single),
-      context: .init(descriptor: methodDescriptor)
+      context: .init(descriptor: methodDescriptor, cancellation: .init())
     ) { _, _ in
       { [serviceContext = ServiceContext.current] in
         return StreamingServerResponse<String>(


### PR DESCRIPTION
## Motivation
We should depend on `grpc-swift/main` for now to make sure that everything works cross-package.

## Modifications
This PR changes `grpc-swift-extras` to depend on `main` for `grpc-swift`. It also fixes some tests as a result of adding the cancellation handler to the API.

## Result
`grpc-swift-extras` builds with the latest `grpc-swift` changes.