### PR TITLE
Add more build settings to test targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/grpc/grpc-swift-protobuf.git",
-    exact: "1.0.0-alpha.1"
+    branch: "main"
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
@@ -47,7 +47,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/apple/swift-distributed-tracing.git",
-    from: "1.0.0"
+    from: "1.1.2"
   ),
 ]
 
@@ -73,7 +73,8 @@ let targets: [Target] = [
     dependencies: [
       .target(name: "GRPCHealthService"),
       .product(name: "GRPCInProcessTransport", package: "grpc-swift"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   ),
 
   // Common interceptors for gRPC.
@@ -91,7 +92,8 @@ let targets: [Target] = [
       .target(name: "GRPCInterceptors"),
       .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "Tracing", package: "swift-distributed-tracing")
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   ),
 
   // gRPC interop test implementation.
@@ -110,7 +112,8 @@ let targets: [Target] = [
       .target(name: "GRPCInteropTests"),
       .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "GRPCInProcessTransport", package: "grpc-swift"),
-    ]
+    ],
+    swiftSettings: defaultSwiftSettings
   )
 ]
 

--- a/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/ServerTracingInterceptor.swift
@@ -56,7 +56,10 @@ public struct ServerTracingInterceptor: ServerInterceptor {
       using: self.extractor
     )
 
-    return try await ServiceContext.withValue(serviceContext) {
+    // FIXME: use 'ServiceContext.withValue(serviceContext)'
+    //
+    // This is blocked on: https://github.com/apple/swift-service-context/pull/46
+    return try await ServiceContext.$current.withValue(serviceContext) {
       try await tracer.withSpan(
         context.descriptor.fullyQualifiedMethod,
         context: serviceContext,

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -32,7 +32,10 @@ final class TracingInterceptorTests: XCTestCase {
     let (stream, continuation) = AsyncStream<String>.makeStream()
     serviceContext.traceID = traceIDString
 
-    try await ServiceContext.withValue(serviceContext) {
+    // FIXME: use 'ServiceContext.withValue(serviceContext)'
+    //
+    // This is blocked on: https://github.com/apple/swift-service-context/pull/46
+    try await ServiceContext.$current.withValue(serviceContext) {
       let methodDescriptor = MethodDescriptor(
         service: "TracingInterceptorTests",
         method: "testClientInterceptor"
@@ -101,7 +104,10 @@ final class TracingInterceptorTests: XCTestCase {
     let (stream, continuation) = AsyncStream<String>.makeStream()
     serviceContext.traceID = traceIDString
 
-    try await ServiceContext.withValue(serviceContext) {
+    // FIXME: use 'ServiceContext.withValue(serviceContext)'
+    //
+    // This is blocked on: https://github.com/apple/swift-service-context/pull/46
+    try await ServiceContext.$current.withValue(serviceContext) {
       let response = try await interceptor.intercept(
         request: .init(producer: { writer in
           try await writer.write(contentsOf: ["request1"])


### PR DESCRIPTION
Motivation:

The test targets don't set the same Swift as the library targets. There's no reason for them not to.

Modifications:

- Apply default settings to test targets.
- Workaround service-context bug

Result:

Test targets use Swift 6 language mode, explicit existential any, and internal imports by default