### PR TITLE
Add missing import

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -72,6 +72,7 @@ let targets: [Target] = [
     name: "GRPCHealthServiceTests",
     dependencies: [
       .target(name: "GRPCHealthService"),
+      .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "GRPCInProcessTransport", package: "grpc-swift"),
     ],
     swiftSettings: defaultSwiftSettings

--- a/Tests/GRPCHealthServiceTests/HealthTests.swift
+++ b/Tests/GRPCHealthServiceTests/HealthTests.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import GRPCCore
 import GRPCHealthService
 import GRPCInProcessTransport
 import XCTest


### PR DESCRIPTION
Motivation:

The 'GRPCCore' import was missing from the health tests.

Modifications:

- Add missing import

Result:

More correct imports