### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -131,3 +131,14 @@ let package = Package(
   dependencies: dependencies,
   targets: targets
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+  if target.type != .plugin {
+    var settings = target.swiftSettings ?? []
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+    settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+    target.swiftSettings = settings
+  }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,7 @@ let defaultSwiftSettings: [SwiftSetting] = [
   .swiftLanguageMode(.v6),
   .enableUpcomingFeature("ExistentialAny"),
   .enableUpcomingFeature("InternalImportsByDefault"),
+  .enableUpcomingFeature("MemberImportVisibility"),
 ]
 
 let targets: [Target] = [
@@ -131,14 +132,3 @@ let package = Package(
   dependencies: dependencies,
   targets: targets
 )
-
-// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
-for target in package.targets {
-  if target.type != .plugin {
-    var settings = target.swiftSettings ?? []
-    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
-    settings.append(.enableUpcomingFeature("MemberImportVisibility"))
-    target.swiftSettings = settings
-  }
-}
-// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
@@ -15,7 +15,7 @@
  */
 
 internal import GRPCCore
-import SwiftProtobuf
+private import SwiftProtobuf
 
 private import struct Foundation.Data
 

--- a/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
@@ -15,6 +15,7 @@
  */
 
 internal import GRPCCore
+import SwiftProtobuf
 
 private import struct Foundation.Data
 

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -16,7 +16,7 @@
 
 private import Foundation
 public import GRPCCore
-import SwiftProtobuf
+private import SwiftProtobuf
 
 public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -16,6 +16,7 @@
 
 private import Foundation
 public import GRPCCore
+import SwiftProtobuf
 
 public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}

--- a/Tests/GRPCHealthServiceTests/HealthTests.swift
+++ b/Tests/GRPCHealthServiceTests/HealthTests.swift
@@ -17,6 +17,7 @@
 import GRPCCore
 import GRPCHealthService
 import GRPCInProcessTransport
+import SwiftProtobuf
 import XCTest
 
 final class HealthTests: XCTestCase {


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.