### PR TITLE
Use FoundationEssentials where possible

### DIFF
--- a/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
@@ -17,7 +17,11 @@
 internal import GRPCCore
 private import SwiftProtobuf
 
+#if canImport(FoundationEssentials)
+private import struct FoundationEssentials.Data
+#else
 private import struct Foundation.Data
+#endif
 
 /// This test verifies that implementations support zero-size messages. Ideally, client
 /// implementations would verify that the request and response were zero bytes serialized, but

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-private import Foundation
 public import GRPCCore
 private import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+private import struct FoundationEssentials.Data
+#else
+private import struct Foundation.Data
+#endif
 
 public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}


### PR DESCRIPTION
Motivation:

FoundationEssentials only includes ... the essentials. We should use it where available.

Modifications:

- Replace Foundation imports with FoundationEssentials import

Result:

Smaller dependency set