### PR TITLE
Add support for the reflection service

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,10 @@ let products: [Product] = [
     targets: ["GRPCHealthService"]
   ),
   .library(
+    name: "GRPCReflectionService",
+    targets: ["GRPCReflectionService"]
+  ),
+  .library(
     name: "GRPCInterceptors",
     targets: ["GRPCInterceptors"]
   ),
@@ -75,6 +79,30 @@ let targets: [Target] = [
       .target(name: "GRPCHealthService"),
       .product(name: "GRPCCore", package: "grpc-swift"),
       .product(name: "GRPCInProcessTransport", package: "grpc-swift"),
+    ],
+    swiftSettings: defaultSwiftSettings
+  ),
+
+  // An implementation of the gRPC Reflection service.
+  .target(
+    name: "GRPCReflectionService",
+    dependencies: [
+      .product(name: "GRPCCore", package: "grpc-swift"),
+      .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf"),
+      .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+    ],
+    swiftSettings: defaultSwiftSettings
+  ),
+  .testTarget(
+    name: "GRPCReflectionServiceTests",
+    dependencies: [
+      .target(name: "GRPCReflectionService"),
+      .product(name: "GRPCCore", package: "grpc-swift"),
+      .product(name: "GRPCInProcessTransport", package: "grpc-swift"),
+      .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+    ],
+    resources: [
+      .copy("Generated/DescriptorSets")
     ],
     swiftSettings: defaultSwiftSettings
   ),

--- a/Sources/GRPCReflectionService/Service/ReflectionService+V1.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionService+V1.swift
@@ -15,6 +15,7 @@
  */
 
 internal import GRPCCore
+internal import SwiftProtobuf
 
 extension ReflectionService {
   struct V1: Grpc_Reflection_V1_ServerReflection.SimpleServiceProtocol {

--- a/Sources/GRPCReflectionService/Service/ReflectionService+V1.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionService+V1.swift
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+internal import GRPCCore
+
+extension ReflectionService {
+  struct V1: Grpc_Reflection_V1_ServerReflection.SimpleServiceProtocol {
+    private typealias Response = Grpc_Reflection_V1_ServerReflectionResponse
+    private typealias ResponsePayload = Response.OneOf_MessageResponse
+    private typealias FileDescriptorResponse = Grpc_Reflection_V1_FileDescriptorResponse
+    private typealias ExtensionNumberResponse = Grpc_Reflection_V1_ExtensionNumberResponse
+    private let registry: ReflectionServiceRegistry
+
+    init(registry: ReflectionServiceRegistry) {
+      self.registry = registry
+    }
+  }
+}
+
+extension ReflectionService.V1 {
+  private func findFileByFileName(_ fileName: String) throws(RPCError) -> FileDescriptorResponse {
+    let data = try self.registry.serialisedFileDescriptorForDependenciesOfFile(named: fileName)
+    return .with { $0.fileDescriptorProto = data }
+  }
+
+  func serverReflectionInfo(
+    request: RPCAsyncSequence<Grpc_Reflection_V1_ServerReflectionRequest, any Swift.Error>,
+    response: RPCWriter<Grpc_Reflection_V1_ServerReflectionResponse>,
+    context: ServerContext
+  ) async throws {
+    for try await message in request {
+      let payload: ResponsePayload
+
+      switch message.messageRequest {
+      case let .fileByFilename(fileName):
+        payload = .makeFileDescriptorResponse { () throws(RPCError) -> FileDescriptorResponse in
+          try self.findFileByFileName(fileName)
+        }
+
+      case .listServices:
+        payload = .listServicesResponse(
+          .with {
+            $0.service = self.registry.serviceNames.map { serviceName in
+              .with { $0.name = serviceName }
+            }
+          }
+        )
+
+      case let .fileContainingSymbol(symbolName):
+        payload = .makeFileDescriptorResponse { () throws(RPCError) -> FileDescriptorResponse in
+          let fileName = try self.registry.fileContainingSymbol(symbolName)
+          return try self.findFileByFileName(fileName)
+        }
+
+      case let .fileContainingExtension(extensionRequest):
+        payload = .makeFileDescriptorResponse { () throws(RPCError) -> FileDescriptorResponse in
+          let fileName = try self.registry.fileContainingExtension(
+            extendeeName: extensionRequest.containingType,
+            fieldNumber: extensionRequest.extensionNumber
+          )
+          return try self.findFileByFileName(fileName)
+        }
+
+      case let .allExtensionNumbersOfType(typeName):
+        payload = .makeExtensionNumberResponse { () throws(RPCError) -> ExtensionNumberResponse in
+          let fieldNumbers = try self.registry.extensionFieldNumbersOfType(named: typeName)
+          return .with {
+            $0.extensionNumber = fieldNumbers
+            $0.baseTypeName = typeName
+          }
+        }
+
+      default:
+        payload = .errorResponse(
+          .with {
+            $0.errorCode = Int32(RPCError.Code.unimplemented.rawValue)
+            $0.errorMessage = "The request is not implemented."
+          }
+        )
+      }
+
+      try await response.write(Response(request: message, response: payload))
+    }
+  }
+}
+
+extension Grpc_Reflection_V1_ServerReflectionResponse.OneOf_MessageResponse {
+  fileprivate init(catching body: () throws(RPCError) -> Self) {
+    do {
+      self = try body()
+    } catch {
+      self = .errorResponse(
+        .with {
+          $0.errorCode = Int32(error.code.rawValue)
+          $0.errorMessage = error.message
+        }
+      )
+    }
+  }
+
+  fileprivate static func makeFileDescriptorResponse(
+    _ body: () throws(RPCError) -> Grpc_Reflection_V1_FileDescriptorResponse
+  ) -> Self {
+    Self { () throws(RPCError) -> Self in
+      return .fileDescriptorResponse(try body())
+    }
+  }
+
+  fileprivate static func makeExtensionNumberResponse(
+    _ body: () throws(RPCError) -> Grpc_Reflection_V1_ExtensionNumberResponse
+  ) -> Self {
+    Self { () throws(RPCError) -> Self in
+      return .allExtensionNumbersResponse(try body())
+    }
+  }
+}
+
+extension Grpc_Reflection_V1_ServerReflectionResponse {
+  fileprivate init(
+    request: Grpc_Reflection_V1_ServerReflectionRequest,
+    response: Self.OneOf_MessageResponse
+  ) {
+    self = .with {
+      $0.validHost = request.host
+      $0.originalRequest = request
+      $0.messageResponse = response
+    }
+  }
+}

--- a/Sources/GRPCReflectionService/Service/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionService.swift
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+private import DequeModule
+public import GRPCCore
+public import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+public import struct FoundationEssentials.URL
+public import struct FoundationEssentials.Data
+#else
+public import struct Foundation.URL
+public import struct Foundation.Data
+#endif
+
+/// Implements the gRPC Reflection service (v1).
+///
+/// The reflection service is a regular gRPC service providing information about other
+/// services.
+///
+/// The service will offer information to clients about any registered services. You can register
+/// a service by providing its descriptor set to the service.
+public final class ReflectionService: Sendable {
+  private let service: ReflectionService.V1
+
+  /// Create a new instance of the reflection service from a list of descriptor set file URLs.
+  ///
+  /// - Parameter fileURLs: A list of file URLs containing serialized descriptor sets.
+  public convenience init(
+    descriptorSetFileURLs fileURLs: [URL]
+  ) throws {
+    let fileDescriptorProtos = try Self.readDescriptorSets(atURLs: fileURLs)
+    try self.init(fileDescriptors: fileDescriptorProtos)
+  }
+
+  /// Create a new instance of the reflection service from a list of descriptor set file paths.
+  ///
+  /// - Parameter filePaths: A list of file paths containing serialized descriptor sets.
+  public convenience init(
+    descriptorSetFilePaths filePaths: [String]
+  ) throws {
+    let fileDescriptorProtos = try Self.readDescriptorSets(atPaths: filePaths)
+    try self.init(fileDescriptors: fileDescriptorProtos)
+  }
+
+  /// Create a new instance of the reflection service from a list of file descriptor messages.
+  ///
+  /// - Parameter fileDescriptors: A list of file descriptors of the services to register.
+  public init(
+    fileDescriptors: [Google_Protobuf_FileDescriptorProto]
+  ) throws {
+    let registry = try ReflectionServiceRegistry(fileDescriptors: fileDescriptors)
+    self.service = ReflectionService.V1(registry: registry)
+  }
+}
+
+extension ReflectionService: RegistrableRPCService {
+  public func registerMethods(with router: inout RPCRouter) {
+    self.service.registerMethods(with: &router)
+  }
+}
+
+extension ReflectionService {
+  static func readSerializedFileDescriptorProto(
+    atPath path: String
+  ) throws -> Google_Protobuf_FileDescriptorProto {
+    let fileURL: URL
+    #if canImport(Darwin)
+    fileURL = URL(filePath: path, directoryHint: .notDirectory)
+    #else
+    fileURL = URL(fileURLWithPath: path)
+    #endif
+
+    let binaryData = try Data(contentsOf: fileURL)
+    guard let serializedData = Data(base64Encoded: binaryData) else {
+      throw RPCError(
+        code: .invalidArgument,
+        message:
+          """
+          The \(path) file contents could not be transformed \
+          into serialized data representing a file descriptor proto.
+          """
+      )
+    }
+
+    return try Google_Protobuf_FileDescriptorProto(serializedBytes: serializedData)
+  }
+
+  static func readSerializedFileDescriptorProtos(
+    atPaths paths: [String]
+  ) throws -> [Google_Protobuf_FileDescriptorProto] {
+    var fileDescriptorProtos = [Google_Protobuf_FileDescriptorProto]()
+    fileDescriptorProtos.reserveCapacity(paths.count)
+    for path in paths {
+      try fileDescriptorProtos.append(Self.readSerializedFileDescriptorProto(atPath: path))
+    }
+    return fileDescriptorProtos
+  }
+
+  static func readDescriptorSet(
+    atURL fileURL: URL
+  ) throws -> [Google_Protobuf_FileDescriptorProto] {
+    let binaryData = try Data(contentsOf: fileURL)
+    let descriptorSet = try Google_Protobuf_FileDescriptorSet(serializedBytes: binaryData)
+    return descriptorSet.file
+  }
+
+  static func readDescriptorSet(
+    atPath path: String
+  ) throws -> [Google_Protobuf_FileDescriptorProto] {
+    let fileURL: URL
+    #if canImport(Darwin)
+    fileURL = URL(filePath: path, directoryHint: .notDirectory)
+    #else
+    fileURL = URL(fileURLWithPath: path)
+    #endif
+    return try Self.readDescriptorSet(atURL: fileURL)
+  }
+
+  static func readDescriptorSets(
+    atURLs fileURLs: [URL]
+  ) throws -> [Google_Protobuf_FileDescriptorProto] {
+    var fileDescriptorProtos = [Google_Protobuf_FileDescriptorProto]()
+    fileDescriptorProtos.reserveCapacity(fileURLs.count)
+    for url in fileURLs {
+      try fileDescriptorProtos.append(contentsOf: Self.readDescriptorSet(atURL: url))
+    }
+    return fileDescriptorProtos
+  }
+
+  static func readDescriptorSets(
+    atPaths paths: [String]
+  ) throws -> [Google_Protobuf_FileDescriptorProto] {
+    var fileDescriptorProtos = [Google_Protobuf_FileDescriptorProto]()
+    fileDescriptorProtos.reserveCapacity(paths.count)
+    for path in paths {
+      try fileDescriptorProtos.append(contentsOf: Self.readDescriptorSet(atPath: path))
+    }
+    return fileDescriptorProtos
+  }
+}

--- a/Sources/GRPCReflectionService/Service/ReflectionServiceRegistry.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionServiceRegistry.swift
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+private import DequeModule
+package import GRPCCore
+package import SwiftProtobuf
+
+#if canImport(FoundationEssentials)
+package import struct FoundationEssentials.Data
+#else
+package import struct Foundation.Data
+#endif
+
+package struct ReflectionServiceRegistry: Sendable {
+  private struct SerializedFileDescriptor: Sendable {
+    var bytes: Data
+    var dependencyFileNames: [String]
+  }
+
+  private struct ExtensionDescriptor: Sendable, Hashable {
+    var extendeeTypeName: String
+    var fieldNumber: Int32
+  }
+
+  private var fileDescriptorDataByFilename: [String: SerializedFileDescriptor]
+  private var fileNameBySymbol: [String: String]
+  private(set) var serviceNames: [String]
+
+  // Stores the file names for each extension identified by an ExtensionDescriptor object.
+  private var fileNameByExtensionDescriptor: [ExtensionDescriptor: String]
+  // Stores the field numbers for each type that has extensions.
+  private var fieldNumbersByType: [String: [Int32]]
+
+  private mutating func storeSerialized(
+    descriptor: Google_Protobuf_FileDescriptorProto
+  ) throws(RPCError) {
+    let serializedBytes: Data
+    do {
+      serializedBytes = try descriptor.serializedBytes()
+    } catch {
+      throw RPCError(
+        code: .invalidArgument,
+        message: "\(descriptor.name) couldn't be serialized.",
+        cause: error
+      )
+    }
+
+    let protoData = SerializedFileDescriptor(
+      bytes: serializedBytes,
+      dependencyFileNames: descriptor.dependency
+    )
+
+    self.fileDescriptorDataByFilename[descriptor.name] = protoData
+  }
+
+  private mutating func storeServices(descriptor: Google_Protobuf_FileDescriptorProto) {
+    let serviceNames = descriptor.service.map { descriptor.package + "." + $0.name }
+    self.serviceNames.append(contentsOf: serviceNames)
+  }
+
+  private mutating func storeSymbolNames(
+    descriptor: Google_Protobuf_FileDescriptorProto
+  ) {
+    for symbol in descriptor.qualifiedSymbolNames {
+      self.fileNameBySymbol[symbol] = descriptor.name
+    }
+  }
+
+  private mutating func storeFieldNumbers(
+    descriptor: Google_Protobuf_FileDescriptorProto
+  ) {
+    for `extension` in descriptor.extension {
+      let typeName = String(`extension`.extendee.drop(while: { $0 == "." }))
+      let extensionDescriptor = ExtensionDescriptor(
+        extendeeTypeName: typeName,
+        fieldNumber: `extension`.number
+      )
+
+      self.fileNameByExtensionDescriptor[extensionDescriptor] = descriptor.name
+      self.fieldNumbersByType[typeName, default: []].append(`extension`.number)
+    }
+  }
+
+  package init(fileDescriptors: [Google_Protobuf_FileDescriptorProto]) throws(RPCError) {
+    self.serviceNames = []
+    self.fileDescriptorDataByFilename = [:]
+    self.fileNameBySymbol = [:]
+    self.fileNameByExtensionDescriptor = [:]
+    self.fieldNumbersByType = [:]
+
+    for descriptor in fileDescriptors {
+      try self.storeSerialized(descriptor: descriptor)
+      self.storeServices(descriptor: descriptor)
+      self.storeSymbolNames(descriptor: descriptor)
+      self.storeFieldNumbers(descriptor: descriptor)
+    }
+  }
+
+  package func serialisedFileDescriptorForDependenciesOfFile(
+    named fileName: String
+  ) throws(RPCError) -> [Data] {
+    var toVisit = Deque<String>()
+    var visited = Set<String>()
+    var serializedBytess: [Data] = []
+    toVisit.append(fileName)
+
+    while let currentFileName = toVisit.popFirst() {
+      if let protoData = self.fileDescriptorDataByFilename[currentFileName] {
+        for dependency in protoData.dependencyFileNames {
+          if !visited.contains(dependency) {
+            toVisit.append(dependency)
+          }
+        }
+
+        let serializedBytes = protoData.bytes
+        serializedBytess.append(serializedBytes)
+      } else {
+        throw RPCError(code: .notFound, message: "File not found.")
+      }
+      visited.insert(currentFileName)
+    }
+    return serializedBytess
+  }
+
+  package func fileContainingSymbol(_ symbolName: String) throws(RPCError) -> String {
+    if let fileName = self.fileNameBySymbol[symbolName] {
+      return fileName
+    } else {
+      throw RPCError(code: .notFound, message: "Symbol not found.")
+    }
+  }
+
+  package func fileContainingExtension(
+    extendeeName: String,
+    fieldNumber number: Int32
+  ) throws(RPCError) -> String {
+    let key = ExtensionDescriptor(extendeeTypeName: extendeeName, fieldNumber: number)
+    if let fileName = self.fileNameByExtensionDescriptor[key] {
+      return fileName
+    } else {
+      throw RPCError(code: .notFound, message: "Extension not found.")
+    }
+  }
+
+  // Returns an empty array if the type has no extensions.
+  package func extensionFieldNumbersOfType(
+    named typeName: String
+  ) throws(RPCError) -> [Int32] {
+    if let fieldNumbers = self.fieldNumbersByType[typeName] {
+      return fieldNumbers
+    } else {
+      throw RPCError(
+        code: .invalidArgument,
+        message: "The provided type is invalid."
+      )
+    }
+  }
+}
+
+extension Google_Protobuf_FileDescriptorProto {
+  fileprivate var qualifiedSymbolNames: [String] {
+    var names: [String] = []
+
+    for service in self.service {
+      names.append(self.package + "." + service.name)
+
+      for method in service.method {
+        names.append(self.package + "." + service.name + "." + method.name)
+      }
+    }
+
+    for messageType in self.messageType {
+      names.append(self.package + "." + messageType.name)
+    }
+
+    for enumType in self.enumType {
+      names.append(self.package + "." + enumType.name)
+    }
+
+    return names
+  }
+}

--- a/Tests/GRPCReflectionServiceTests/GRPCReflectionServiceTests.swift
+++ b/Tests/GRPCReflectionServiceTests/GRPCReflectionServiceTests.swift
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import GRPCCore
+import GRPCInProcessTransport
+import GRPCReflectionService
+import Testing
+
+@Suite("gRPC Reflection Service Tests")
+struct GRPCReflectionServiceTests {
+  func withReflectionClient(
+    descriptorSetPaths: [String] = Bundle.module.pathsForDescriptorSets,
+    execute body: (ReflectionClient) async throws -> Void
+  ) async throws {
+    let inProcess = InProcessTransport()
+    try await withGRPCServer(
+      transport: inProcess.server,
+      services: [ReflectionService(descriptorSetFilePaths: descriptorSetPaths)]
+    ) { server in
+      try await withGRPCClient(transport: inProcess.client) { client in
+        try await body(ReflectionClient(wrapping: client))
+      }
+    }
+  }
+
+  @Test("List services")
+  func listServices() async throws {
+    try await self.withReflectionClient { reflection in
+      let services = try await reflection.listServices()
+      let expected = [
+        "grpc.health.v1.Health",
+        "grpc.reflection.v1.ServerReflection",
+      ]
+      #expect(services.sorted() == expected)
+    }
+  }
+
+  @Test(
+    "File by file name",
+    arguments: [
+      "grpc/reflection/v1/reflection.proto",
+      "grpc/health/v1/health.proto",
+    ]
+  )
+  func fileByFileName(fileName: String) async throws {
+    try await self.withReflectionClient { reflection in
+      let descriptors = try await reflection.fileByFileName(fileName)
+      let expected = [fileName]
+      #expect(descriptors.map { $0.name } == expected)
+    }
+  }
+
+  @Test("File by file name (doesn't exist)")
+  func testFileByNonExistentFileName() async throws {
+    try await self.withReflectionClient { reflection in
+      await #expect {
+        try await reflection.fileByFileName("nonExistent.proto")
+      } throws: { error in
+        guard let error = error as? RPCError else { return false }
+        #expect(error.code == .notFound)
+        #expect(error.message == "File not found.")
+        return true
+      }
+    }
+  }
+
+  @Test(
+    "File containing symbol",
+    arguments: [
+      ("grpc/health/v1/health.proto", "grpc.health.v1.Health"),
+      ("grpc/health/v1/health.proto", "grpc.health.v1.HealthCheckRequest"),
+      ("grpc/reflection/v1/reflection.proto", "grpc.reflection.v1.ServerReflectionRequest"),
+      ("grpc/reflection/v1/reflection.proto", "grpc.reflection.v1.ExtensionNumberResponse"),
+      ("grpc/reflection/v1/reflection.proto", "grpc.reflection.v1.ErrorResponse"),
+    ] as [(String, String)]
+  )
+  func fileContainingSymbol(fileName: String, symbol: String) async throws {
+    try await self.withReflectionClient { reflection in
+      let descriptors = try await reflection.fileContainingSymbol(symbol)
+      let expected = [fileName]
+      #expect(descriptors.map { $0.name } == expected)
+    }
+  }
+
+  @Test("File containing symbol includes dependencies")
+  func fileContainingSymbolWithDependency() async throws {
+    try await self.withReflectionClient { reflection in
+      let descriptors = try await reflection.fileContainingSymbol(".MessageWithDependency")
+      let expected = ["message_with_dependency.proto", "google/protobuf/empty.proto"]
+      #expect(descriptors.map { $0.name } == expected)
+    }
+  }
+
+  @Test("File containing symbol (doesn't exist)")
+  func testFileContainingNonExistentSymbol() async throws {
+    try await self.withReflectionClient { reflection in
+      await #expect {
+        try await reflection.fileContainingSymbol("nonExistentSymbol")
+      } throws: { error in
+        guard let error = error as? RPCError else { return false }
+        #expect(error.code == .notFound)
+        #expect(error.message == "Symbol not found.")
+        return true
+      }
+    }
+  }
+
+  @Test("File containing extension")
+  func testFileContainingExtension() async throws {
+    try await self.withReflectionClient { reflection in
+      let descriptors = try await reflection.fileContainingExtension(number: 100, in: "BaseMessage")
+      let expected = ["base_message.proto"]
+      #expect(descriptors.map { $0.name } == expected)
+    }
+  }
+
+  @Test("File containing extension (doesn't exist)")
+  func testFileContainingNonExistentExtension() async throws {
+    try await self.withReflectionClient { reflection in
+      await #expect {
+        try await reflection.fileContainingExtension(number: 42, in: "NonExistent")
+      } throws: { error in
+        guard let error = error as? RPCError else { return false }
+        #expect(error.code == .notFound)
+        #expect(error.message == "Extension not found.")
+        return true
+      }
+    }
+  }
+}
+
+extension Bundle {
+  func path(forDescriptorSet name: String) -> String? {
+    self.path(forResource: name, ofType: "pb", inDirectory: "DescriptorSets")
+  }
+
+  var pathsForDescriptorSets: [String] {
+    self.paths(forResourcesOfType: "pb", inDirectory: "DescriptorSets")
+  }
+}

--- a/Tests/GRPCReflectionServiceTests/ReflectionClient.swift
+++ b/Tests/GRPCReflectionServiceTests/ReflectionClient.swift
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import GRPCCore
+import GRPCReflectionService
+import SwiftProtobuf
+
+struct ReflectionClient: Sendable {
+  private typealias Request = Grpc_Reflection_V1_ServerReflectionRequest
+  private let stub: Grpc_Reflection_V1_ServerReflection.Client
+
+  init(wrapping client: GRPCClient) {
+    self.stub = Grpc_Reflection_V1_ServerReflection.Client(wrapping: client)
+  }
+
+  func listServices() async throws -> [String] {
+    try await self.stub.serverReflectionInfo { requestStream in
+      // 'listServices' must be set, but its contents is ignored.
+      let request = Self.Request.with { $0.listServices = "" }
+      try await requestStream.write(request)
+    } onResponse: { response in
+      for try await message in response.messages {
+        switch message.messageResponse {
+        case .listServicesResponse(let response):
+          return response.service.map { $0.name }
+        default:
+          continue
+        }
+      }
+      throw RPCError(code: .internalError, message: "No list services response.")
+    }
+  }
+
+  func fileByFileName(_ name: String) async throws -> [Google_Protobuf_FileDescriptorProto] {
+    try await self.fileDescriptorsResponse(forRequest: .with { $0.fileByFilename = name })
+  }
+
+  func fileContainingSymbol(_ name: String) async throws -> [Google_Protobuf_FileDescriptorProto] {
+    try await self.fileDescriptorsResponse(forRequest: .with { $0.fileContainingSymbol = name })
+  }
+
+  func fileContainingExtension(
+    number: Int32,
+    in containingType: String
+  ) async throws -> [Google_Protobuf_FileDescriptorProto] {
+    try await self.fileDescriptorsResponse(
+      forRequest: .with {
+        $0.fileContainingExtension = .with {
+          $0.containingType = containingType
+          $0.extensionNumber = number
+        }
+      }
+    )
+  }
+
+  private func fileDescriptorsResponse(
+    forRequest request: Grpc_Reflection_V1_ServerReflectionRequest
+  ) async throws -> [Google_Protobuf_FileDescriptorProto] {
+    try await self.stub.serverReflectionInfo { requestStream in
+      try await requestStream.write(request)
+    } onResponse: { response in
+      for try await message in response.messages {
+        switch message.messageResponse {
+        case .fileDescriptorResponse(let response):
+          return try response.fileDescriptorProto.map {
+            try Google_Protobuf_FileDescriptorProto(serializedBytes: $0)
+          }
+
+        case .errorResponse(let response):
+          let code = Status.Code(rawValue: Int(response.errorCode))
+          throw RPCError(
+            code: code.flatMap { RPCError.Code($0) } ?? .unknown,
+            message: response.errorMessage
+          )
+
+        default:
+          continue
+        }
+      }
+
+      throw RPCError(code: .internalError, message: "No list services response.")
+    }
+  }
+
+}

--- a/Tests/GRPCReflectionServiceTests/ReflectionClient.swift
+++ b/Tests/GRPCReflectionServiceTests/ReflectionClient.swift
@@ -28,7 +28,7 @@ struct ReflectionClient: Sendable {
 
   func listServices() async throws -> [String] {
     try await self.stub.serverReflectionInfo { requestStream in
-      // 'listServices' must be set, but its contents is ignored.
+      // 'listServices' must be set, but its contents are ignored.
       let request = Self.Request.with { $0.listServices = "" }
       try await requestStream.write(request)
     } onResponse: { response in


### PR DESCRIPTION
Motivation:

The reflection service is widely used and we should offer an implementation out-of-the-box.

Modifications:

- Add back an updated version of the reflection service from grpc-swift v1.

Result:

Can use reflection service