### PR TITLE
Add missing test import

### DIFF
--- a/Tests/GRPCReflectionServiceTests/GRPCReflectionServiceTests.swift
+++ b/Tests/GRPCReflectionServiceTests/GRPCReflectionServiceTests.swift
@@ -18,6 +18,7 @@ import Foundation
 import GRPCCore
 import GRPCInProcessTransport
 import GRPCReflectionService
+import SwiftProtobuf
 import Testing
 
 @Suite("gRPC Reflection Service Tests")


### PR DESCRIPTION
Motivation:

I noticed nightly-main failed because of a missing import in tests. Auto-merge
blasted over this previously.

Modifications:

Add the missing import.

Result:

nightly-main passes.