### PR TITLE
Conform server tracing interceptor to OTel's conventions

### DIFF
--- a/Sources/GRPCInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -42,7 +42,7 @@ public struct ClientOTelTracingInterceptor: ClientInterceptor {
   ///  - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the
   ///  `network.transport` attribute in spans.
   ///  - traceEachMessage: If `true`, each request part sent and response part received will be recorded as a separate
-  ///  event in a tracing span. Otherwise, only the request/response start and end will be recorded as events.
+  ///  event in a tracing span.
   public init(
     serverHostname: String,
     networkTransportMethod: String,

--- a/Sources/GRPCInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -21,9 +21,14 @@ package import Tracing
 /// A client interceptor that injects tracing information into the request.
 ///
 /// The tracing information is taken from the current `ServiceContext`, and injected into the request's
-/// metadata. It will then be picked up by the server-side ``ServerTracingInterceptor``.
+/// metadata. It will then be picked up by the server-side ``ServerOTelTracingInterceptor``.
 ///
 /// For more information, refer to the documentation for `swift-distributed-tracing`.
+///
+/// This interceptor will also inject all required and recommended span and event attributes, and set span status, as defined by
+/// OpenTelemetry's documentation on:
+/// - https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans
+/// - https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
 public struct ClientOTelTracingInterceptor: ClientInterceptor {
   private let injector: ClientRequestInjector
   private let traceEachMessage: Bool

--- a/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -68,7 +68,7 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
     request: StreamingServerRequest<Input>,
     context: ServerContext,
     next: @Sendable (StreamingServerRequest<Input>, ServerContext) async throws ->
-    StreamingServerResponse<Output>
+      StreamingServerResponse<Output>
   ) async throws -> StreamingServerResponse<Output> where Input: Sendable, Output: Sendable {
     try await self.intercept(
       tracer: InstrumentationSystem.tracer,
@@ -116,7 +116,8 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
             wrapping: request.messages.map { element in
               var event = SpanEvent(name: "rpc.message")
               event.attributes[GRPCTracingKeys.rpcMessageType] = "RECEIVED"
-              event.attributes[GRPCTracingKeys.rpcMessageID] = messageReceivedCounter
+              event.attributes[GRPCTracingKeys.rpcMessageID] =
+                messageReceivedCounter
                 .wrappingAdd(1, ordering: .sequentiallyConsistent)
                 .oldValue
               span.addEvent(event)
@@ -139,7 +140,8 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
                 afterEachWrite: {
                   var event = SpanEvent(name: "rpc.message")
                   event.attributes[GRPCTracingKeys.rpcMessageType] = "SENT"
-                  event.attributes[GRPCTracingKeys.rpcMessageID] = messageSentCounter
+                  event.attributes[GRPCTracingKeys.rpcMessageID] =
+                    messageSentCounter
                     .wrappingAdd(1, ordering: .sequentiallyConsistent)
                     .oldValue
                   span.addEvent(event)

--- a/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -154,10 +154,6 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
 
               return wrappedResult
             }
-          } else {
-            success.producer = { writer in
-              return try await wrappedProducer(writer)
-            }
           }
 
           response = .init(accepted: .success(success))

--- a/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -15,13 +15,13 @@
  */
 
 public import GRPCCore
-internal import Tracing
 internal import Synchronization
+internal import Tracing
 
 /// A server interceptor that extracts tracing information from the request.
 ///
 /// The extracted tracing information is made available to user code via the current `ServiceContext`.
-/// 
+///
 /// For more information, refer to the documentation for `swift-distributed-tracing`.
 ///
 /// This interceptor will also inject all required and recommended span and event attributes, and set span status, as defined by
@@ -104,7 +104,7 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
               var event = SpanEvent(name: "rpc.message")
               event.attributes.rpc.messageType = "RECEIVED"
               event.attributes.rpc.messageID =
-              messageReceivedCounter
+                messageReceivedCounter
                 .wrappingAdd(1, ordering: .sequentiallyConsistent)
                 .oldValue
               span.addEvent(event)
@@ -130,7 +130,7 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
                   var event = SpanEvent(name: "rpc.message")
                   event.attributes.rpc.messageType = "SENT"
                   event.attributes.rpc.messageID =
-                  messageSentCounter
+                    messageSentCounter
                     .wrappingAdd(1, ordering: .sequentiallyConsistent)
                     .oldValue
                   span.addEvent(event)

--- a/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -38,7 +38,7 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
   ///
   /// - Parameters:
   ///  - severHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
-  ///  - networkTransportMethod: The transport in use (e.g. "tcp", "udp"). This will be the value for the
+  ///  - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the
   ///  `network.transport` attribute in spans.
   ///  - traceEachMessage: If `true`, each response part sent and request part received will be recorded as a separate
   ///  event in a tracing span.

--- a/Tests/GRPCInterceptorsTests/OTelTracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/OTelTracingInterceptorTests.swift
@@ -18,7 +18,7 @@ import GRPCCore
 import GRPCInterceptors
 import Testing
 import Tracing
-import XCTest
+import struct Foundation.UUID
 
 @Suite("OTel Tracing Client Interceptor Tests")
 struct OTelTracingClientInterceptorTests {
@@ -27,8 +27,6 @@ struct OTelTracingClientInterceptorTests {
   init() {
     self.tracer = TestTracer()
   }
-
-  // - MARK: Client Interceptor Tests
 
   @Test(
     "Successful RPC is recorded correctly",
@@ -91,7 +89,7 @@ struct OTelTracingClientInterceptorTests {
       await assertStreamContentsEqual(["request1", "request2"], requestStream)
       try await assertStreamContentsEqual([["response"]], response.messages)
 
-      assertTestSpanComponents(forMethod: methodDescriptor) { events in
+      assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
         // No events are recorded
         #expect(events.isEmpty)
       } assertAttributes: { attributes in
@@ -160,7 +158,7 @@ struct OTelTracingClientInterceptorTests {
       await assertStreamContentsEqual(["request1", "request2"], requestStream)
       try await assertStreamContentsEqual([["response"]], response.messages)
 
-      assertTestSpanComponents(forMethod: methodDescriptor) { events in
+      assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
         #expect(
           events == [
             // Recorded when `request1` is sent
@@ -217,7 +215,7 @@ struct OTelTracingClientInterceptorTests {
         }
         Issue.record("Should have thrown")
       } catch {
-        assertTestSpanComponents(forMethod: methodDescriptor) { events in
+        assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
           // No events are recorded
           #expect(events.isEmpty)
         } assertAttributes: { attributes in
@@ -297,7 +295,7 @@ struct OTelTracingClientInterceptorTests {
         #expect(failure == RPCError(code: .unavailable, message: "This should not work"))
       }
 
-      assertTestSpanComponents(forMethod: methodDescriptor) { events in
+      assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
         // No events are recorded
         #expect(events.isEmpty)
       } assertAttributes: { attributes in
@@ -387,7 +385,7 @@ struct OTelTracingClientInterceptorTests {
         return
       }
 
-      assertTestSpanComponents(forMethod: methodDescriptor) { events in
+      assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
         // No events are recorded
         #expect(events.isEmpty)
       } assertAttributes: { attributes in
@@ -406,16 +404,12 @@ struct OTelTracingClientInterceptorTests {
           ]
         )
       } assertStatus: { status in
-        XCTAssertEqual(status, .some(.init(code: .error)))
         #expect(status == .some(.init(code: .error)))
       } assertErrors: { errors in
-        XCTAssertEqual(errors.count, 1)
         #expect(errors.count == 1)
       }
     }
   }
-
-  // - MARK: Utilities
 
   private func getTestValues(
     addressType: OTelTracingInterceptorTestAddressType,
@@ -474,98 +468,49 @@ struct OTelTracingClientInterceptorTests {
       )
     }
   }
-
-  private func getTestSpanForMethod(_ methodDescriptor: MethodDescriptor) -> TestSpan {
-    return self.tracer.getSpan(ofOperation: methodDescriptor.fullyQualifiedMethod)!
-  }
-
-  private func assertTestSpanComponents(
-    forMethod method: MethodDescriptor,
-    assertEvents: ([TestSpanEvent]) -> Void,
-    assertAttributes: (SpanAttributes) -> Void,
-    assertStatus: (SpanStatus?) -> Void,
-    assertErrors: ([TracingInterceptorTestError]) -> Void
-  ) {
-    let span = self.getTestSpanForMethod(method)
-    assertEvents(span.events.map({ TestSpanEvent($0) }))
-    assertAttributes(span.attributes)
-    assertStatus(span.status)
-    assertErrors(span.errors)
-  }
-
-  private func assertStreamContentsEqual<T: Equatable>(
-    _ array: [T],
-    _ stream: any AsyncSequence<T, any Error>
-  ) async throws {
-    var streamElements = [T]()
-    for try await element in stream {
-      streamElements.append(element)
-    }
-    #expect(streamElements == array)
-  }
-
-  private func assertStreamContentsEqual<T: Equatable>(
-    _ array: [T],
-    _ stream: any AsyncSequence<T, Never>
-  ) async {
-    var streamElements = [T]()
-    for await element in stream {
-      streamElements.append(element)
-    }
-    #expect(streamElements == array)
-  }
 }
 
-final class TracingInterceptorTests: XCTestCase {
-  override class func setUp() {
-    InstrumentationSystem.bootstrap(TestTracer())
+@Suite("OTel Tracing Server Interceptor Tests")
+struct OTelTracingServerInterceptorTests {
+  private let tracer: TestTracer
+
+  init() {
+    self.tracer = TestTracer()
   }
 
-  // - MARK: Server Interceptor Tests
-
-  func testServerInterceptorErrorResponse() async throws {
+  @Test(
+    "Successful RPC is recorded correctly",
+    arguments: OTelTracingInterceptorTestAddressType.allCases
+  )
+  func testSuccessfulRPC(addressType: OTelTracingInterceptorTestAddressType) async throws {
     let methodDescriptor = MethodDescriptor(
-      fullyQualifiedService: "TracingInterceptorTests",
-      method: "testServerInterceptorErrorResponse"
-    )
-    let interceptor = ServerTracingInterceptor(emitEventOnEachWrite: false)
-    let single = ServerRequest(metadata: ["trace-id": "some-trace-id"], message: [UInt8]())
-    let response = try await interceptor.intercept(
-      request: .init(single: single),
-      context: ServerContext(
-        descriptor: methodDescriptor,
-        remotePeer: "",
-        localPeer: "",
-        cancellation: .init()
-      )
-    ) { _, _ in
-      StreamingServerResponse<String>(error: .init(code: .unknown, message: "Test error"))
-    }
-    XCTAssertThrowsError(try response.accepted.get())
-  func testServerInterceptor_IPv4() async throws {
-    let methodDescriptor = MethodDescriptor(
-      fullyQualifiedService: "TracingInterceptorTests",
-      method: "testServerInterceptor"
+      fullyQualifiedService: "OTelTracingServerInterceptorTests",
+      method: "testSuccessfulRPC"
     )
     let interceptor = ServerOTelTracingInterceptor(
       serverHostname: "someserver.com",
       networkTransportMethod: "tcp",
-      emitEventOnEachWrite: false
-
+      traceEachMessage: false
     )
     let traceIDString = UUID().uuidString
     let request = ServerRequest(metadata: ["trace-id": .string(traceIDString)], message: [UInt8]())
+
+    let testValues = self.getTestValues(
+      addressType: addressType,
+      methodDescriptor: methodDescriptor
+    )
     let response = try await interceptor.intercept(
+      tracer: self.tracer,
       request: .init(single: request),
       context: ServerContext(
         descriptor: methodDescriptor,
-        remotePeer: "ipv4:10.1.2.80:567",
-        localPeer: "ipv4:10.1.2.90:123",
+        remotePeer: testValues.remotePeerAddress,
+        localPeer: testValues.localPeerAddress,
         cancellation: .init()
       )
     ) { _, _ in
       // Make sure we get the metadata injected into our service context
-      XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
+      #expect(ServiceContext.current?.traceID == traceIDString)
 
       return StreamingServerResponse<String>(
         accepted: .success(
@@ -589,226 +534,46 @@ final class TracingInterceptorTests: XCTestCase {
     )
     responseStreamContinuation.finish()
 
-    await AssertStreamContentsEqual(["response1", "response2"], responseStream)
-    XCTAssertEqual(trailingMetadata, ["Result": "Trailing metadata"])
+    await assertStreamContentsEqual(["response1", "response2"], responseStream)
+    #expect(trailingMetadata == ["Result": "Trailing metadata"])
 
-    AssertTestSpanComponents(forMethod: methodDescriptor) { events in
-      XCTAssertEqual(
-        events.map({ $0.name }),
-        [
-          "Received request",
-          "Finished processing request",
-          "Sent response end",
-        ]
-      )
+    assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
+      #expect(events.isEmpty)
     } assertAttributes: { attributes in
-      XCTAssertEqual(
-        attributes,
-        [
-          "rpc.system": .string("grpc"),
-          "rpc.method": .string(methodDescriptor.method),
-          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-          "server.address": .string("someserver.com"),
-          "server.port": .int(123),
-          "network.peer.address": .string("10.1.2.90"),
-          "network.peer.port": .int(123),
-          "network.transport": .string("tcp"),
-          "network.type": .string("ipv4"),
-          "client.address": .string("10.1.2.80"),
-          "client.port": .int(567),
-        ]
-      )
+      #expect(attributes == testValues.expectedSpanAttributes)
     } assertStatus: { status in
-      XCTAssertNil(status)
+      #expect(status == nil)
     } assertErrors: { errors in
-      XCTAssertEqual(errors, [])
+      #expect(errors.isEmpty)
     }
   }
 
-  func testServerInterceptor_IPv6() async throws {
+  @Test("All events are recorded when traceEachMessage is true")
+  func testAllEventsRecorded() async throws {
     let methodDescriptor = MethodDescriptor(
-      fullyQualifiedService: "TracingInterceptorTests",
-      method: "testServerInterceptor"
+      fullyQualifiedService: "OTelTracingServerInterceptorTests",
+      method: "testAllEventsRecorded"
     )
     let interceptor = ServerOTelTracingInterceptor(
       serverHostname: "someserver.com",
       networkTransportMethod: "tcp",
-      emitEventOnEachWrite: false
+      traceEachMessage: true
     )
     let traceIDString = UUID().uuidString
     let request = ServerRequest(metadata: ["trace-id": .string(traceIDString)], message: [UInt8]())
+    let testValues = getTestValues(addressType: .ipv4, methodDescriptor: methodDescriptor)
     let response = try await interceptor.intercept(
+      tracer: self.tracer,
       request: .init(single: request),
       context: ServerContext(
         descriptor: methodDescriptor,
-        remotePeer: "ipv6:[2001::130F:::09C0:876A:130B]:1234",
-        localPeer: "ipv6:[ff06:0:0:0:0:0:0:c3]:5678",
-        cancellation: .init()
-      )
-    ) { _, _ in
-      // Make sure we get the metadata injected into our service context
-      XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
-
-      return StreamingServerResponse<String>(
-        accepted: .success(
-          .init(
-            metadata: [],
-            producer: { writer in
-              try await writer.write("response1")
-              try await writer.write("response2")
-              return ["Result": "Trailing metadata"]
-            }
-          )
-        )
-      )
-    }
-
-    // Get the response out into a response stream, and assert its contents
-    let (responseStream, responseStreamContinuation) = AsyncStream<String>.makeStream()
-    let responseContents = try response.accepted.get()
-    let trailingMetadata = try await responseContents.producer(
-      RPCWriter(wrapping: TestWriter(streamContinuation: responseStreamContinuation))
-    )
-    responseStreamContinuation.finish()
-
-    XCTAssertEqual(trailingMetadata, ["Result": "Trailing metadata"])
-    await AssertStreamContentsEqual(["response1", "response2"], responseStream)
-
-    AssertTestSpanComponents(forMethod: methodDescriptor) { events in
-      XCTAssertEqual(
-        events.map({ $0.name }),
-        [
-          "Received request",
-          "Finished processing request",
-          "Sent response end",
-        ]
-      )
-    } assertAttributes: { attributes in
-      XCTAssertEqual(
-        attributes,
-        [
-          "rpc.system": .string("grpc"),
-          "rpc.method": .string(methodDescriptor.method),
-          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-          "server.address": .string("someserver.com"),
-          "server.port": .int(5678),
-          "network.peer.address": .string("ff06:0:0:0:0:0:0:c3"),
-          "network.peer.port": .int(5678),
-          "network.transport": .string("tcp"),
-          "network.type": .string("ipv6"),
-          "client.address": .string("2001::130F:::09C0:876A:130B"),
-          "client.port": .int(1234),
-        ]
-      )
-    } assertStatus: { status in
-      XCTAssertNil(status)
-    } assertErrors: { errors in
-      XCTAssertEqual(errors, [])
-    }
-  }
-
-  func testServerInterceptor_UDS() async throws {
-    let methodDescriptor = MethodDescriptor(
-      fullyQualifiedService: "TracingInterceptorTests",
-      method: "testServerInterceptor"
-    )
-    let interceptor = ServerOTelTracingInterceptor(
-      serverHostname: "someserver.com",
-      networkTransportMethod: "tcp",
-      emitEventOnEachWrite: false
-    )
-    let traceIDString = UUID().uuidString
-    let request = ServerRequest(metadata: ["trace-id": .string(traceIDString)], message: [UInt8]())
-    let response = try await interceptor.intercept(
-      request: .init(single: request),
-      context: ServerContext(
-        descriptor: methodDescriptor,
-        remotePeer: "unix:some-path",
-        localPeer: "unix:some-path",
-        cancellation: .init()
-      )
-    ) { _, _ in
-      // Make sure we get the metadata injected into our service context
-      XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
-
-      return StreamingServerResponse<String>(
-        accepted: .success(
-          .init(
-            metadata: [],
-            producer: { writer in
-              try await writer.write("response1")
-              try await writer.write("response2")
-              return ["Result": "Trailing metadata"]
-            }
-          )
-        )
-      )
-    }
-
-    // Get the response out into a response stream, and assert its contents
-    let (responseStream, responseStreamContinuation) = AsyncStream<String>.makeStream()
-    let responseContents = try response.accepted.get()
-    let trailingMetadata = try await responseContents.producer(
-      RPCWriter(wrapping: TestWriter(streamContinuation: responseStreamContinuation))
-    )
-    responseStreamContinuation.finish()
-
-    XCTAssertEqual(trailingMetadata, ["Result": "Trailing metadata"])
-    await AssertStreamContentsEqual(["response1", "response2"], responseStream)
-
-    AssertTestSpanComponents(forMethod: methodDescriptor) { events in
-      XCTAssertEqual(
-        events.map({ $0.name }),
-        [
-          "Received request",
-          "Finished processing request",
-          "Sent response end",
-        ]
-      )
-    } assertAttributes: { attributes in
-      XCTAssertEqual(
-        attributes,
-        [
-          "rpc.system": .string("grpc"),
-          "rpc.method": .string(methodDescriptor.method),
-          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-          "server.address": .string("someserver.com"),
-          "network.peer.address": .string("some-path"),
-          "network.transport": .string("tcp"),
-          "network.type": .string("unix"),
-          "client.address": .string("some-path"),
-        ]
-      )
-    } assertStatus: { status in
-      XCTAssertNil(status)
-    } assertErrors: { errors in
-      XCTAssertEqual(errors, [])
-    }
-  }
-
-  func testServerInterceptorAllEventsRecorded() async throws {
-    let methodDescriptor = MethodDescriptor(
-      fullyQualifiedService: "TracingInterceptorTests",
-      method: "testServerInterceptorAllEventsRecorded"
-    )
-    let interceptor = ServerOTelTracingInterceptor(
-      serverHostname: "someserver.com",
-      networkTransportMethod: "tcp",
-      emitEventOnEachWrite: true
-    )
-    let traceIDString = UUID().uuidString
-    let request = ServerRequest(metadata: ["trace-id": .string(traceIDString)], message: [UInt8]())
-    let response = try await interceptor.intercept(
-      request: .init(single: request),
-      context: ServerContext(
-        descriptor: methodDescriptor,
-        remotePeer: "ipv4:10.1.2.80:567",
-        localPeer: "ipv4:10.1.2.90:123",
+        remotePeer: testValues.remotePeerAddress,
+        localPeer: testValues.localPeerAddress,
         cancellation: .init()
       )
     ) { request, _ in
       // Make sure we get the metadata injected into our service context
-      XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
+      #expect(ServiceContext.current?.traceID == traceIDString)
 
       for try await _ in request.messages {
         // We need to iterate over the messages for the span to be able to record the events.
@@ -836,51 +601,31 @@ final class TracingInterceptorTests: XCTestCase {
     )
     responseStreamContinuation.finish()
 
-    XCTAssertEqual(trailingMetadata, ["Result": "Trailing metadata"])
-    await AssertStreamContentsEqual(["response1", "response2"], responseStream)
+    #expect(trailingMetadata == ["Result": "Trailing metadata"])
+    await assertStreamContentsEqual(["response1", "response2"], responseStream)
 
-    AssertTestSpanComponents(forMethod: methodDescriptor) { events in
-      XCTAssertEqual(
-        events,
+    assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
+      #expect(events ==
         [
-          TestSpanEvent("Received request", [:]),
           // Recorded when request is received
           TestSpanEvent("rpc.message", ["rpc.message.type": "RECEIVED", "rpc.message.id": 1]),
-          // Recorded after all request parts have been received
-          TestSpanEvent("Finished processing request", [:]),
           // Recorded when `response1` is sent
           TestSpanEvent("rpc.message", ["rpc.message.type": "SENT", "rpc.message.id": 1]),
           // Recorded when `response2` is sent
           TestSpanEvent("rpc.message", ["rpc.message.type": "SENT", "rpc.message.id": 2]),
-          // Recorded at end of response
-          TestSpanEvent("Sent response end", [:]),
         ]
       )
     } assertAttributes: { attributes in
-      XCTAssertEqual(
-        attributes,
-        [
-          "rpc.system": .string("grpc"),
-          "rpc.method": .string(methodDescriptor.method),
-          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-          "server.address": .string("someserver.com"),
-          "server.port": .int(123),
-          "network.peer.address": .string("10.1.2.90"),
-          "network.peer.port": .int(123),
-          "network.transport": .string("tcp"),
-          "network.type": .string("ipv4"),
-          "client.address": .string("10.1.2.80"),
-          "client.port": .int(567),
-        ]
-      )
+      #expect(attributes == testValues.expectedSpanAttributes)
     } assertStatus: { status in
-      XCTAssertNil(status)
+      #expect(status == nil)
     } assertErrors: { errors in
-      XCTAssertEqual(errors, [])
+      #expect(errors.isEmpty)
     }
   }
 
-  func testServerInterceptorErrorEncountered() async throws {
+  @Test("RPC that throws is correctly recorded")
+  func testThrowingRPC() async throws {
     let methodDescriptor = MethodDescriptor(
       fullyQualifiedService: "TracingInterceptorTests",
       method: "testServerInterceptorErrorEncountered"
@@ -888,56 +633,44 @@ final class TracingInterceptorTests: XCTestCase {
     let interceptor = ServerOTelTracingInterceptor(
       serverHostname: "someserver.com",
       networkTransportMethod: "tcp",
-      emitEventOnEachWrite: false
+      traceEachMessage: false
     )
     let traceIDString = UUID().uuidString
     let request = ServerRequest(metadata: ["trace-id": .string(traceIDString)], message: [UInt8]())
+    let testValues = getTestValues(addressType: .ipv4, methodDescriptor: methodDescriptor)
     do {
       let _: StreamingServerResponse<String> = try await interceptor.intercept(
+        tracer: self.tracer,
         request: .init(single: request),
         context: ServerContext(
           descriptor: methodDescriptor,
-          remotePeer: "ipv4:10.1.2.80:567",
-          localPeer: "ipv4:10.1.2.90:123",
+          remotePeer: testValues.remotePeerAddress,
+          localPeer: testValues.localPeerAddress,
           cancellation: .init()
         )
       ) { _, _ in
         // Make sure we get the metadata injected into our service context
-        XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
+        #expect(ServiceContext.current?.traceID == traceIDString)
 
         throw TracingInterceptorTestError.testError
       }
-      XCTFail("Should have thrown")
+      Issue.record("Should have thrown")
     } catch {
-      AssertTestSpanComponents(forMethod: methodDescriptor) { events in
-        XCTAssertEqual(events.map({ $0.name }), ["Received request"])
+      assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
+        #expect(events.isEmpty)
       } assertAttributes: { attributes in
         // The attributes should not contain a grpc status code, as the request was never even sent.
-        XCTAssertEqual(
-          attributes,
-          [
-            "rpc.system": .string("grpc"),
-            "rpc.method": .string(methodDescriptor.method),
-            "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-            "server.address": .string("someserver.com"),
-            "server.port": .int(123),
-            "network.peer.address": .string("10.1.2.90"),
-            "network.peer.port": .int(123),
-            "network.transport": .string("tcp"),
-            "network.type": .string("ipv4"),
-            "client.address": .string("10.1.2.80"),
-            "client.port": .int(567),
-          ]
-        )
+        #expect(attributes == testValues.expectedSpanAttributes)
       } assertStatus: { status in
-        XCTAssertNil(status)
+        #expect(status == nil)
       } assertErrors: { errors in
-        XCTAssertEqual(errors, [.testError])
+        #expect(errors == [.testError])
       }
     }
   }
 
-  func testServerInterceptorErrorResponse() async throws {
+  @Test("RPC with a failure response is correctly recorded")
+  func testFailedRPC() async throws {
     let methodDescriptor = MethodDescriptor(
       fullyQualifiedService: "TracingInterceptorTests",
       method: "testServerInterceptorErrorResponse"
@@ -945,105 +678,159 @@ final class TracingInterceptorTests: XCTestCase {
     let interceptor = ServerOTelTracingInterceptor(
       serverHostname: "someserver.com",
       networkTransportMethod: "tcp",
-      emitEventOnEachWrite: false
+      traceEachMessage: false
     )
     let traceIDString = UUID().uuidString
     let request = ServerRequest(metadata: ["trace-id": .string(traceIDString)], message: [UInt8]())
+    let testValues = getTestValues(addressType: .ipv4, methodDescriptor: methodDescriptor)
     let response = try await interceptor.intercept(
+      tracer: self.tracer,
       request: .init(single: request),
       context: ServerContext(
         descriptor: methodDescriptor,
-        remotePeer: "ipv4:10.1.2.80:567",
-        localPeer: "ipv4:10.1.2.90:123",
+        remotePeer: testValues.remotePeerAddress,
+        localPeer: testValues.localPeerAddress,
         cancellation: .init()
       )
     ) { _, _ in
       // Make sure we get the metadata injected into our service context
-      XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
+      #expect(ServiceContext.current?.traceID == traceIDString)
 
       return StreamingServerResponse<String>(
         error: RPCError(code: .unavailable, message: "Test error")
       )
     }
 
-    XCTAssertThrowsError(try response.accepted.get())
+    #expect(throws: RPCError.self) {
+      try response.accepted.get()
+    }
 
-    AssertTestSpanComponents(forMethod: methodDescriptor) { events in
-      XCTAssertEqual(
-        events.map({ $0.name }),
-        [
-          "Received request",
-          "Finished processing request",
-          "Sent error response",
-        ]
-      )
+    assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
+      #expect(events.isEmpty)
     } assertAttributes: { attributes in
-      XCTAssertEqual(
-        attributes,
-        [
-          "rpc.system": .string("grpc"),
+      #expect(attributes == [
+        "rpc.system": "grpc",
+        "rpc.method": .string(methodDescriptor.method),
+        "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
+        "rpc.grpc.status_code": 14,  // this is unavailable's raw code
+        "server.address": "someserver.com",
+        "server.port": 123,
+        "network.peer.address": "10.1.2.90",
+        "network.peer.port": 123,
+        "network.transport": "tcp",
+        "network.type": "ipv4",
+        "client.address": "10.1.2.80",
+        "client.port": 567,
+      ])
+    } assertStatus: { status in
+      #expect(status == .some(.init(code: .error)))
+    } assertErrors: { errors in
+      #expect(errors.count == 1)
+    }
+  }
+
+  private func getTestValues(
+    addressType: OTelTracingInterceptorTestAddressType,
+    methodDescriptor: MethodDescriptor
+  ) -> OTelTracingInterceptorTestCaseValues {
+    switch addressType {
+    case .ipv4:
+      return OTelTracingInterceptorTestCaseValues(
+        remotePeerAddress: "ipv4:10.1.2.80:567",
+        localPeerAddress: "ipv4:10.1.2.90:123",
+        expectedSpanAttributes: [
+          "rpc.system": "grpc",
           "rpc.method": .string(methodDescriptor.method),
           "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-          "rpc.grpc.status_code": .int(14),  // this is unavailable's raw code
-          "server.address": .string("someserver.com"),
-          "server.port": .int(123),
-          "network.peer.address": .string("10.1.2.90"),
-          "network.peer.port": .int(123),
-          "network.transport": .string("tcp"),
-          "network.type": .string("ipv4"),
-          "client.address": .string("10.1.2.80"),
-          "client.port": .int(567),
+          "server.address": "someserver.com",
+          "server.port": 123,
+          "network.peer.address": "10.1.2.90",
+          "network.peer.port": 123,
+          "network.transport": "tcp",
+          "network.type": "ipv4",
+          "client.address": "10.1.2.80",
+          "client.port": 567,
         ]
       )
-    } assertStatus: { status in
-      XCTAssertEqual(status, .some(.init(code: .error)))
-    } assertErrors: { errors in
-      XCTAssertEqual(errors.count, 1)
+
+    case .ipv6:
+      return OTelTracingInterceptorTestCaseValues(
+        remotePeerAddress: "ipv6:[2001::130F:::09C0:876A:130B]:1234",
+        localPeerAddress: "ipv6:[ff06:0:0:0:0:0:0:c3]:5678",
+        expectedSpanAttributes: [
+          "rpc.system": "grpc",
+          "rpc.method": .string(methodDescriptor.method),
+          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
+          "server.address": "someserver.com",
+          "server.port": 5678,
+          "network.peer.address": "ff06:0:0:0:0:0:0:c3",
+          "network.peer.port": 5678,
+          "network.transport": "tcp",
+          "network.type": "ipv6",
+          "client.address": "2001::130F:::09C0:876A:130B",
+          "client.port": 1234,
+        ]
+      )
+
+    case .uds:
+      return OTelTracingInterceptorTestCaseValues(
+        remotePeerAddress: "unix:some-path",
+        localPeerAddress: "unix:some-path",
+        expectedSpanAttributes: [
+          "rpc.system": "grpc",
+          "rpc.method": .string(methodDescriptor.method),
+          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
+          "server.address": "someserver.com",
+          "network.peer.address": "some-path",
+          "network.transport": "tcp",
+          "client.address": "some-path",
+        ]
+      )
     }
   }
+}
 
-  // -  MARK: Utilities
+// -  MARK: Utilities
 
-  private func getTestSpanForMethod(_ methodDescriptor: MethodDescriptor) -> TestSpan {
-    let tracer = InstrumentationSystem.tracer as! TestTracer
-    return tracer.getSpan(ofOperation: methodDescriptor.fullyQualifiedMethod)!
+fileprivate func getTestSpanForMethod(tracer: TestTracer, methodDescriptor: MethodDescriptor) -> TestSpan {
+  tracer.getSpan(ofOperation: methodDescriptor.fullyQualifiedMethod)!
+}
+
+fileprivate func assertTestSpanComponents(
+  forMethod method: MethodDescriptor,
+  tracer: TestTracer,
+  assertEvents: ([TestSpanEvent]) -> Void,
+  assertAttributes: (SpanAttributes) -> Void,
+  assertStatus: (SpanStatus?) -> Void,
+  assertErrors: ([TracingInterceptorTestError]) -> Void
+) {
+  let span = getTestSpanForMethod(tracer: tracer, methodDescriptor: method)
+  assertEvents(span.events.map({ TestSpanEvent($0) }))
+  assertAttributes(span.attributes)
+  assertStatus(span.status)
+  assertErrors(span.errors)
+}
+
+fileprivate func assertStreamContentsEqual<T: Equatable>(
+  _ array: [T],
+  _ stream: any AsyncSequence<T, any Error>
+) async throws {
+  var streamElements = [T]()
+  for try await element in stream {
+    streamElements.append(element)
   }
+  #expect(streamElements == array)
+}
 
-  private func assertTestSpanComponents(
-    forMethod method: MethodDescriptor,
-    assertEvents: ([TestSpanEvent]) -> Void,
-    assertAttributes: (SpanAttributes) -> Void,
-    assertStatus: (SpanStatus?) -> Void,
-    assertErrors: ([TracingInterceptorTestError]) -> Void
-  ) {
-    let span = self.getTestSpanForMethod(method)
-    assertEvents(span.events.map({ TestSpanEvent($0) }))
-    assertAttributes(span.attributes)
-    assertStatus(span.status)
-    assertErrors(span.errors)
+fileprivate func assertStreamContentsEqual<T: Equatable>(
+  _ array: [T],
+  _ stream: any AsyncSequence<T, Never>
+) async {
+  var streamElements = [T]()
+  for await element in stream {
+    streamElements.append(element)
   }
-
-  private func assertStreamContentsEqual<T: Equatable>(
-    _ array: [T],
-    _ stream: any AsyncSequence<T, any Error>
-  ) async throws {
-    var streamElements = [T]()
-    for try await element in stream {
-      streamElements.append(element)
-    }
-    XCTAssertEqual(streamElements, array)
-  }
-
-  private func assertStreamContentsEqual<T: Equatable>(
-    _ array: [T],
-    _ stream: any AsyncSequence<T, Never>
-  ) async {
-    var streamElements = [T]()
-    for await element in stream {
-      streamElements.append(element)
-    }
-    XCTAssertEqual(streamElements, array)
-  }
+  #expect(streamElements == array)
 }
 
 enum OTelTracingInterceptorTestAddressType {

--- a/Tests/GRPCInterceptorsTests/OTelTracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/OTelTracingInterceptorTests.swift
@@ -18,6 +18,7 @@ import GRPCCore
 import GRPCInterceptors
 import Testing
 import Tracing
+
 import struct Foundation.UUID
 
 @Suite("OTel Tracing Client Interceptor Tests")
@@ -605,8 +606,8 @@ struct OTelTracingServerInterceptorTests {
     await assertStreamContentsEqual(["response1", "response2"], responseStream)
 
     assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
-      #expect(events ==
-        [
+      #expect(
+        events == [
           // Recorded when request is received
           TestSpanEvent("rpc.message", ["rpc.message.type": "RECEIVED", "rpc.message.id": 1]),
           // Recorded when `response1` is sent
@@ -708,20 +709,22 @@ struct OTelTracingServerInterceptorTests {
     assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
       #expect(events.isEmpty)
     } assertAttributes: { attributes in
-      #expect(attributes == [
-        "rpc.system": "grpc",
-        "rpc.method": .string(methodDescriptor.method),
-        "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
-        "rpc.grpc.status_code": 14,  // this is unavailable's raw code
-        "server.address": "someserver.com",
-        "server.port": 123,
-        "network.peer.address": "10.1.2.90",
-        "network.peer.port": 123,
-        "network.transport": "tcp",
-        "network.type": "ipv4",
-        "client.address": "10.1.2.80",
-        "client.port": 567,
-      ])
+      #expect(
+        attributes == [
+          "rpc.system": "grpc",
+          "rpc.method": .string(methodDescriptor.method),
+          "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
+          "rpc.grpc.status_code": 14,  // this is unavailable's raw code
+          "server.address": "someserver.com",
+          "server.port": 123,
+          "network.peer.address": "10.1.2.90",
+          "network.peer.port": 123,
+          "network.transport": "tcp",
+          "network.type": "ipv4",
+          "client.address": "10.1.2.80",
+          "client.port": 567,
+        ]
+      )
     } assertStatus: { status in
       #expect(status == .some(.init(code: .error)))
     } assertErrors: { errors in
@@ -792,11 +795,14 @@ struct OTelTracingServerInterceptorTests {
 
 // -  MARK: Utilities
 
-fileprivate func getTestSpanForMethod(tracer: TestTracer, methodDescriptor: MethodDescriptor) -> TestSpan {
+private func getTestSpanForMethod(
+  tracer: TestTracer,
+  methodDescriptor: MethodDescriptor
+) -> TestSpan {
   tracer.getSpan(ofOperation: methodDescriptor.fullyQualifiedMethod)!
 }
 
-fileprivate func assertTestSpanComponents(
+private func assertTestSpanComponents(
   forMethod method: MethodDescriptor,
   tracer: TestTracer,
   assertEvents: ([TestSpanEvent]) -> Void,
@@ -811,7 +817,7 @@ fileprivate func assertTestSpanComponents(
   assertErrors(span.errors)
 }
 
-fileprivate func assertStreamContentsEqual<T: Equatable>(
+private func assertStreamContentsEqual<T: Equatable>(
   _ array: [T],
   _ stream: any AsyncSequence<T, any Error>
 ) async throws {
@@ -822,7 +828,7 @@ fileprivate func assertStreamContentsEqual<T: Equatable>(
   #expect(streamElements == array)
 }
 
-fileprivate func assertStreamContentsEqual<T: Equatable>(
+private func assertStreamContentsEqual<T: Equatable>(
   _ array: [T],
   _ stream: any AsyncSequence<T, Never>
 ) async {

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -641,8 +641,8 @@ final class TracingInterceptorTests: XCTestCase {
       request: .init(single: request),
       context: ServerContext(
         descriptor: methodDescriptor,
-        remotePeer: "ipv6:2001::130F:::09C0:876A:130B:1234",
-        localPeer: "ipv6:ff06:0:0:0:0:0:0:c3:5678",
+        remotePeer: "ipv6:[2001::130F:::09C0:876A:130B]:1234",
+        localPeer: "ipv6:[ff06:0:0:0:0:0:0:c3]:5678",
         cancellation: .init()
       )
     ) { _, _ in

--- a/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
+++ b/Tests/GRPCInterceptorsTests/TracingInterceptorTests.swift
@@ -598,7 +598,7 @@ final class TracingInterceptorTests: XCTestCase {
         [
           "Received request",
           "Finished processing request",
-          "Sent response end"
+          "Sent response end",
         ]
       )
     } assertAttributes: { attributes in
@@ -615,7 +615,7 @@ final class TracingInterceptorTests: XCTestCase {
           "network.transport": .string("tcp"),
           "network.type": .string("ipv4"),
           "client.address": .string("10.1.2.80"),
-          "client.port": .int(567)
+          "client.port": .int(567),
         ]
       )
     } assertStatus: { status in
@@ -680,7 +680,7 @@ final class TracingInterceptorTests: XCTestCase {
         [
           "Received request",
           "Finished processing request",
-          "Sent response end"
+          "Sent response end",
         ]
       )
     } assertAttributes: { attributes in
@@ -697,7 +697,7 @@ final class TracingInterceptorTests: XCTestCase {
           "network.transport": .string("tcp"),
           "network.type": .string("ipv6"),
           "client.address": .string("2001::130F:::09C0:876A:130B"),
-          "client.port": .int(1234)
+          "client.port": .int(1234),
         ]
       )
     } assertStatus: { status in
@@ -762,7 +762,7 @@ final class TracingInterceptorTests: XCTestCase {
         [
           "Received request",
           "Finished processing request",
-          "Sent response end"
+          "Sent response end",
         ]
       )
     } assertAttributes: { attributes in
@@ -776,7 +776,7 @@ final class TracingInterceptorTests: XCTestCase {
           "network.peer.address": .string("some-path"),
           "network.transport": .string("tcp"),
           "network.type": .string("unix"),
-          "client.address": .string("some-path")
+          "client.address": .string("some-path"),
         ]
       )
     } assertStatus: { status in
@@ -870,7 +870,7 @@ final class TracingInterceptorTests: XCTestCase {
           "network.transport": .string("tcp"),
           "network.type": .string("ipv4"),
           "client.address": .string("10.1.2.80"),
-          "client.port": .int(567)
+          "client.port": .int(567),
         ]
       )
     } assertStatus: { status in
@@ -926,7 +926,7 @@ final class TracingInterceptorTests: XCTestCase {
             "network.transport": .string("tcp"),
             "network.type": .string("ipv4"),
             "client.address": .string("10.1.2.80"),
-            "client.port": .int(567)
+            "client.port": .int(567),
           ]
         )
       } assertStatus: { status in
@@ -961,7 +961,9 @@ final class TracingInterceptorTests: XCTestCase {
       // Make sure we get the metadata injected into our service context
       XCTAssertEqual(ServiceContext.current?.traceID, traceIDString)
 
-      return StreamingServerResponse<String>(error: RPCError(code: .unavailable, message: "Test error"))
+      return StreamingServerResponse<String>(
+        error: RPCError(code: .unavailable, message: "Test error")
+      )
     }
 
     XCTAssertThrowsError(try response.accepted.get())
@@ -972,7 +974,7 @@ final class TracingInterceptorTests: XCTestCase {
         [
           "Received request",
           "Finished processing request",
-          "Sent error response"
+          "Sent error response",
         ]
       )
     } assertAttributes: { attributes in
@@ -990,7 +992,7 @@ final class TracingInterceptorTests: XCTestCase {
           "network.transport": .string("tcp"),
           "network.type": .string("ipv4"),
           "client.address": .string("10.1.2.80"),
-          "client.port": .int(567)
+          "client.port": .int(567),
         ]
       )
     } assertStatus: { status in

--- a/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCInterceptorsTests/TracingTestsUtilities.swift
@@ -210,6 +210,7 @@ struct TestSpanEvent: Equatable, CustomDebugStringConvertible {
   var name: String
   var attributes: SpanAttributes
 
+  // This conformance is so any test errors are nicer to look at and understand
   var debugDescription: String {
     var attributesDescription = ""
     self.attributes.forEach { key, value in


### PR DESCRIPTION
This PR brings the same changes made to the client in https://github.com/grpc/grpc-swift-extras/pull/25 to the server interceptor, conforming it to follow recommendations/conventions laid out in both:
- https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans
- https://opentelemetry.io/docs/specs/semconv/rpc/grpc/