### PR TITLE
Add option to include request/response metadata in tracing interceptors

### DIFF
--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -73,9 +73,6 @@ public struct ClientOTelTracingInterceptor: ClientInterceptor {
   ///  event in a tracing span.
   ///  - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the span as attributes.
   ///  - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the span as attributes.
-  ///
-  /// - Important: Be careful when setting `includeRequestMetadata` or `includeResponseMetadata` to `true`,
-  /// as including all request/response metadata can be a security risk.
   public init(
     serverHostname: String,
     networkTransportMethod: String,

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -162,11 +162,11 @@ public struct ClientOTelTracingInterceptor: ClientInterceptor {
           let messageReceivedCounter = Atomic(1)
           hookedSequence = HookedRPCAsyncSequence(wrapping: success.bodyParts) { part in
             switch part {
-            case .message(let message):
+            case .message:
               var event = SpanEvent(name: "rpc.message")
               event.attributes[GRPCTracingKeys.rpcMessageType] = "RECEIVED"
               event.attributes[GRPCTracingKeys.rpcMessageID] =
-              messageReceivedCounter
+                messageReceivedCounter
                 .wrappingAdd(1, ordering: .sequentiallyConsistent)
                 .oldValue
               span.addEvent(event)

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -46,6 +46,31 @@ public struct ClientOTelTracingInterceptor: ClientInterceptor {
   ///  `network.transport` attribute in spans.
   ///  - traceEachMessage: If `true`, each request part sent and response part received will be recorded as a separate
   ///  event in a tracing span.
+  ///
+  /// - Important: Be careful when setting `includeRequestMetadata` or `includeResponseMetadata` to `true`,
+  /// as including all request/response metadata can be a security risk.
+  public init(
+    serverHostname: String,
+    networkTransportMethod: String,
+    traceEachMessage: Bool = true
+  ) {
+    self.init(
+      serverHostname: serverHostname,
+      networkTransportMethod: networkTransportMethod,
+      traceEachMessage: traceEachMessage,
+      includeRequestMetadata: false,
+      includeResponseMetadata: false
+    )
+  }
+
+  /// Create a new instance of a ``ClientOTelTracingInterceptor``.
+  ///
+  /// - Parameters:
+  ///  - severHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
+  ///  - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the
+  ///  `network.transport` attribute in spans.
+  ///  - traceEachMessage: If `true`, each request part sent and response part received will be recorded as a separate
+  ///  event in a tracing span.
   ///  - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the span as attributes.
   ///  - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the span as attributes.
   ///

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -45,9 +45,6 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
   ///  `network.transport` attribute in spans.
   ///  - traceEachMessage: If `true`, each response part sent and request part received will be recorded as a separate
   ///  event in a tracing span.
-  ///
-  /// - Important: Be careful when setting `includeRequestMetadata` or `includeResponseMetadata` to `true`,
-  /// as including all request/response metadata can be a security risk.
   public init(
     serverHostname: String,
     networkTransportMethod: String,

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -30,9 +30,12 @@ package import Tracing
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
 public struct ServerOTelTracingInterceptor: ServerInterceptor {
   private let extractor: ServerRequestExtractor
-  private let traceEachMessage: Bool
   private var serverHostname: String
   private var networkTransportMethod: String
+
+  private let traceEachMessage: Bool
+  private var includeRequestMetadata: Bool
+  private var includeResponseMetadata: Bool
 
   /// Create a new instance of a ``ServerOTelTracingInterceptor``.
   ///
@@ -42,15 +45,24 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
   ///  `network.transport` attribute in spans.
   ///  - traceEachMessage: If `true`, each response part sent and request part received will be recorded as a separate
   ///  event in a tracing span.
+  ///  - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the span as attributes.
+  ///  - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the span as attributes.
+  ///
+  /// - Important: Be careful when setting `includeRequestMetadata` or `includeResponseMetadata` to `true`,
+  /// as including all request/response metadata can be a security risk.
   public init(
     serverHostname: String,
     networkTransportMethod: String,
-    traceEachMessage: Bool = true
+    traceEachMessage: Bool = true,
+    includeRequestMetadata: Bool = false,
+    includeResponseMetadata: Bool = false
   ) {
     self.extractor = ServerRequestExtractor()
     self.traceEachMessage = traceEachMessage
     self.serverHostname = serverHostname
     self.networkTransportMethod = networkTransportMethod
+    self.includeRequestMetadata = includeRequestMetadata
+    self.includeResponseMetadata = includeResponseMetadata
   }
 
   /// This interceptor will extract whatever `ServiceContext` key-value pairs have been inserted into the
@@ -109,6 +121,10 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
           networkTransportMethod: self.networkTransportMethod
         )
 
+        if self.includeRequestMetadata {
+          span.setMetadataStringAttributesAsRequestSpanAttributes(request.metadata)
+        }
+
         var request = request
         if self.traceEachMessage {
           let messageReceivedCounter = Atomic(1)
@@ -127,6 +143,10 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
         }
 
         var response = try await next(request, context)
+
+        if self.includeResponseMetadata {
+          span.setMetadataStringAttributesAsResponseSpanAttributes(response.metadata)
+        }
 
         switch response.accepted {
         case .success(var success):
@@ -148,11 +168,15 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
                 }
               )
 
-              let wrappedResult = try await wrappedProducer(
+              let trailingMetadata = try await wrappedProducer(
                 RPCWriter(wrapping: eventEmittingWriter)
               )
 
-              return wrappedResult
+              if self.includeResponseMetadata {
+                span.setMetadataStringAttributesAsResponseSpanAttributes(trailingMetadata)
+              }
+
+              return trailingMetadata
             }
           }
 

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -45,6 +45,31 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
   ///  `network.transport` attribute in spans.
   ///  - traceEachMessage: If `true`, each response part sent and request part received will be recorded as a separate
   ///  event in a tracing span.
+  ///
+  /// - Important: Be careful when setting `includeRequestMetadata` or `includeResponseMetadata` to `true`,
+  /// as including all request/response metadata can be a security risk.
+  public init(
+    serverHostname: String,
+    networkTransportMethod: String,
+    traceEachMessage: Bool = true
+  ) {
+    self.init(
+      serverHostname: serverHostname,
+      networkTransportMethod: networkTransportMethod,
+      traceEachMessage: traceEachMessage,
+      includeRequestMetadata: false,
+      includeResponseMetadata: false
+    )
+  }
+
+  /// Create a new instance of a ``ServerOTelTracingInterceptor``.
+  ///
+  /// - Parameters:
+  ///  - severHostname: The hostname of the RPC server. This will be the value for the `server.address` attribute in spans.
+  ///  - networkTransportMethod: The transport in use (e.g. "tcp", "unix"). This will be the value for the
+  ///  `network.transport` attribute in spans.
+  ///  - traceEachMessage: If `true`, each response part sent and request part received will be recorded as a separate
+  ///  event in a tracing span.
   ///  - includeRequestMetadata: if `true`, **all** metadata keys with string values included in the request will be added to the span as attributes.
   ///  - includeResponseMetadata: if `true`, **all** metadata keys with string values included in the response will be added to the span as attributes.
   ///

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -37,6 +37,7 @@ enum GRPCTracingKeys {
   static let networkPeerPort = "network.peer.port"
 
   fileprivate static let requestMetadataPrefix = "rpc.grpc.request.metadata."
+  fileprivate static let responseMetadataPrefix = "rpc.grpc.response.metadata."
 }
 
 extension Span {
@@ -131,6 +132,13 @@ extension Span {
     self.setMetadataStringAttributesAsSpanAttributes(
       metadata,
       prefix: GRPCTracingKeys.requestMetadataPrefix
+    )
+  }
+
+  func setMetadataStringAttributesAsResponseSpanAttributes(_ metadata: Metadata) {
+    self.setMetadataStringAttributesAsSpanAttributes(
+      metadata,
+      prefix: GRPCTracingKeys.responseMetadataPrefix
     )
   }
 

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -158,7 +158,7 @@ extension Span {
             self.attributes[spanKey] = [oldString, stringValue]
 
           default:
-            fatalError("This should never happen: only strings should be iterated here.")
+            ()
           }
         } else {
           self.attributes[spanKey] = stringValue

--- a/Tests/GRPCOTelTracingInterceptorsTests/GRPCOTelTracingInterceptorsTests.swift
+++ b/Tests/GRPCOTelTracingInterceptorsTests/GRPCOTelTracingInterceptorsTests.swift
@@ -180,7 +180,7 @@ struct OTelTracingClientInterceptorTests {
     }
   }
 
-  @Test("All request metadata is included if opted-in")
+  @Test("All string-valued request metadata is included if opted-in")
   func testRequestMetadataOptIn() async throws {
     var serviceContext = ServiceContext.topLevel
     let traceIDString = UUID().uuidString
@@ -199,7 +199,7 @@ struct OTelTracingClientInterceptorTests {
       )
       let methodDescriptor = MethodDescriptor(
         fullyQualifiedService: "OTelTracingClientInterceptorTests",
-        method: "testAllEventsRecorded"
+        method: "testRequestMetadataOptIn"
       )
       let response = try await interceptor.intercept(
         tracer: self.tracer,
@@ -277,6 +277,118 @@ struct OTelTracingClientInterceptorTests {
             "rpc.grpc.request.metadata.some-request-metadata": "some-request-value",
             "rpc.grpc.request.metadata.some-repeated-request-metadata": .stringArray([
               "some-repeated-request-value1", "some-repeated-request-value2",
+            ]),
+          ]
+        )
+      } assertStatus: { status in
+        #expect(status == nil)
+      } assertErrors: { errors in
+        #expect(errors == [])
+      }
+    }
+  }
+
+  @Test("All string-valued response metadata is included if opted-in")
+  func testResponseMetadataOptIn() async throws {
+    var serviceContext = ServiceContext.topLevel
+    let traceIDString = UUID().uuidString
+
+    let (requestStream, requestStreamContinuation) = AsyncStream<String>.makeStream()
+    serviceContext.traceID = traceIDString
+
+    // FIXME: use 'ServiceContext.withValue(serviceContext)'
+    //
+    // This is blocked on: https://github.com/apple/swift-service-context/pull/46
+    try await ServiceContext.$current.withValue(serviceContext) {
+      let interceptor = ClientOTelTracingInterceptor(
+        serverHostname: "someserver.com",
+        networkTransportMethod: "tcp",
+        includeResponseMetadata: true
+      )
+      let methodDescriptor = MethodDescriptor(
+        fullyQualifiedService: "OTelTracingClientInterceptorTests",
+        method: "testResponseMetadataOptIn"
+      )
+      let response = try await interceptor.intercept(
+        tracer: self.tracer,
+        request: .init(
+          metadata: [
+            "some-request-metadata": "some-request-value",
+            "some-repeated-request-metadata": "some-repeated-request-value1",
+            "some-repeated-request-metadata": "some-repeated-request-value2",
+            "some-request-metadata-bin": .binary([1]),
+          ],
+          producer: { writer in
+            try await writer.write(contentsOf: ["request1"])
+            try await writer.write(contentsOf: ["request2"])
+          }
+        ),
+        context: ClientContext(
+          descriptor: methodDescriptor,
+          remotePeer: "ipv4:10.1.2.80:567",
+          localPeer: "ipv4:10.1.2.80:123"
+        )
+      ) { stream, _ in
+        // Assert the metadata contains the injected context key-value.
+        #expect(
+          stream.metadata.contains(where: {
+            ($0.key == "trace-id") && ($0.value == .string(traceIDString))
+          })
+        )
+
+        // Write into the request stream to make sure the `producer` closure's called.
+        let writer = RPCWriter(wrapping: TestWriter(streamContinuation: requestStreamContinuation))
+        try await stream.producer(writer)
+        requestStreamContinuation.finish()
+
+        return .init(
+          metadata: [
+            "some-response-metadata": "some-response-value",
+            "some-response-metadata-bin": .binary([2]),
+          ],
+          bodyParts: RPCAsyncSequence(
+            wrapping: AsyncThrowingStream<StreamingClientResponse.Contents.BodyPart, any Error> {
+              $0.yield(.message(["response"]))
+              $0.yield(.trailingMetadata([
+                "some-repeated-response-metadata": "some-repeated-response-value1",
+                "some-repeated-response-metadata": "some-repeated-response-value2"
+              ]))
+              $0.finish()
+            }
+          )
+        )
+      }
+
+      await assertStreamContentsEqual(["request1", "request2"], requestStream)
+      try await assertStreamContentsEqual([["response"]], response.messages)
+
+      assertTestSpanComponents(forMethod: methodDescriptor, tracer: self.tracer) { events in
+        #expect(
+          events == [
+            // Recorded when `request1` is sent
+            TestSpanEvent("rpc.message", ["rpc.message.type": "SENT", "rpc.message.id": 1]),
+            // Recorded when `request2` is sent
+            TestSpanEvent("rpc.message", ["rpc.message.type": "SENT", "rpc.message.id": 2]),
+            // Recorded when receiving response part
+            TestSpanEvent("rpc.message", ["rpc.message.type": "RECEIVED", "rpc.message.id": 1]),
+          ]
+        )
+      } assertAttributes: { attributes in
+        #expect(
+          attributes == [
+            "rpc.system": "grpc",
+            "rpc.method": .string(methodDescriptor.method),
+            "rpc.service": .string(methodDescriptor.service.fullyQualifiedService),
+            "rpc.grpc.status_code": 0,
+            "server.address": "someserver.com",
+            "server.port": 567,
+            "network.peer.address": "10.1.2.80",
+            "network.peer.port": 567,
+            "network.transport": "tcp",
+            "network.type": "ipv4",
+            "rpc.grpc.response.metadata.some-response-metadata": "some-response-value",
+            "rpc.grpc.response.metadata.some-repeated-response-metadata": .stringArray([
+              "some-repeated-response-value1", "some-repeated-response-value2",
             ]),
           ]
         )


### PR DESCRIPTION
OTel's docs for gRPC conventions (https://opentelemetry.io/docs/specs/semconv/rpc/grpc/) say that libraries _should_ provide the ability to opt-in to include request and response metadata. This PR adds this ability to our tracing interceptors.