### PR TITLE
Make `PeerAddress/init` faster

### DIFF
--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -178,8 +178,9 @@ package enum PeerAddress: Equatable {
       _ = portComponent.popFirst()
 
       if let firstBracket = hostComponent.popFirst(), let lastBracket = hostComponent.popLast(),
-         firstBracket == UInt8(ascii: "["), lastBracket == UInt8(ascii: "]"),
-         let host = String(hostComponent), let port = Int(utf8View: portComponent) {
+        firstBracket == UInt8(ascii: "["), lastBracket == UInt8(ascii: "]"),
+        let host = String(hostComponent), let port = Int(utf8View: portComponent)
+      {
         self = .ipv6(address: host, port: port)
       } else {
         // This is some unexpected/unknown format
@@ -200,7 +201,7 @@ extension Int {
     var value = 0
     for utf8Element in utf8View {
       value &*= 10
-      let elementValue = Int(utf8Element - 48) // ASCII code for 0 is 48
+      let elementValue = Int(utf8Element - 48)  // ASCII code for 0 is 48
       guard elementValue >= 0, elementValue <= 9 else {
         // non-digit character
         return nil

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -215,8 +215,8 @@ extension Int {
       value &+= Int(utf8Char)
     }
 
-    guard value <= 65535 else {
-      // Valid IP port values go up to 2^16-1 = 65535.
+    guard value <= Int(UInt16.max) else {
+      // Valid IP port values go up to 2^16-1.
       // If a number greater than this was given, it can't be a valid port.
       return nil
     }

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -162,8 +162,8 @@ package enum PeerAddress: Equatable {
       var portComponent = addressWithoutType[addressColon...]
       _ = portComponent.popFirst()
 
-      if let host = String(hostComponent), let port = String(portComponent) {
-        self = .ipv4(address: host, port: Int(port))
+      if let host = String(hostComponent), let port = Int(utf8View: portComponent) {
+        self = .ipv4(address: host, port: port)
       } else {
         return nil
       }
@@ -179,8 +179,8 @@ package enum PeerAddress: Equatable {
 
       if let firstBracket = hostComponent.popFirst(), let lastBracket = hostComponent.popLast(),
          firstBracket == UInt8(ascii: "["), lastBracket == UInt8(ascii: "]"),
-         let host = String(hostComponent), let port = String(portComponent) {
-        self = .ipv6(address: host, port: Int(port))
+         let host = String(hostComponent), let port = Int(utf8View: portComponent) {
+        self = .ipv6(address: host, port: port)
       } else {
         // This is some unexpected/unknown format
         return nil
@@ -192,5 +192,21 @@ package enum PeerAddress: Equatable {
       // This is some unexpected/unknown format
       return nil
     }
+  }
+}
+
+extension Int {
+  package init?(utf8View: Substring.UTF8View.SubSequence) {
+    var value = 0
+    for utf8Element in utf8View {
+      value &*= 10
+      let elementValue = Int(utf8Element - 48) // ASCII code for 0 is 48
+      guard elementValue >= 0, elementValue <= 9 else {
+        // non-digit character
+        return nil
+      }
+      value &+= elementValue
+    }
+    self = value
   }
 }

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -212,7 +212,7 @@ extension Int {
         // non-digit character
         return nil
       }
-      value &+= Int(utf8Char)
+      value &+= Int(utf8Char - UInt8(ascii: "0"))
     }
 
     guard value <= Int(UInt16.max) else {

--- a/Tests/GRPCOTelTracingInterceptorsTests/PeerAddressTests.swift
+++ b/Tests/GRPCOTelTracingInterceptorsTests/PeerAddressTests.swift
@@ -68,10 +68,10 @@ struct PeerAddressTests {
       ("65536", nil),  // Invalid: over 65535 IP port limit
       ("654321", nil),  // Invalid: over 5 digits
       ("abc", nil),  // Invalid: no digits
-      ("a123", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
-      ("123a", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
-      ("(123", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
-      ("123(", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
+      ("a123", nil),  // Invalid: mixed digits and chars outside the valid ascii range for digits
+      ("123a", nil),  // Invalid: mixed digits and chars outside the valid ascii range for digits
+      ("(123", nil),  // Invalid: mixed digits and chars outside the valid ascii range for digits
+      ("123(", nil),  // Invalid: mixed digits and chars outside the valid ascii range for digits
       ("", nil),  // Invalid: empty string
     ]
   )

--- a/Tests/GRPCOTelTracingInterceptorsTests/PeerAddressTests.swift
+++ b/Tests/GRPCOTelTracingInterceptorsTests/PeerAddressTests.swift
@@ -57,8 +57,25 @@ struct PeerAddressTests {
     #expect(address == nil)
   }
 
-  @Test("Int.init(utf8View:)")
-  func testIntInitFromUTF8View() async throws {
-    #expect(54321 == Int(utf8View: "54321".utf8[...]))
+  @Test(
+    "Int.init(utf8View:)",
+    arguments: [
+      ("1", 1),
+      ("21", 21),
+      ("321", 321),
+      ("4321", 4321),
+      ("54321", 54321),
+      ("65536", nil),  // Invalid: over 65535 IP port limit
+      ("654321", nil),  // Invalid: over 5 digits
+      ("abc", nil),  // Invalid: no digits
+      ("a123", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
+      ("123a", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
+      ("(123", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
+      ("123(", nil),  // Invalid: mixed digits and characters outside the valid ascii range for digits
+      ("", nil),  // Invalid: empty string
+    ]
+  )
+  func testIntInitFromUTF8View(string: String, expectedInt: Int?) async throws {
+    #expect(expectedInt == Int(ipAddressPortStringBytes: string.utf8))
   }
 }

--- a/Tests/GRPCOTelTracingInterceptorsTests/PeerAddressTests.swift
+++ b/Tests/GRPCOTelTracingInterceptorsTests/PeerAddressTests.swift
@@ -56,4 +56,9 @@ struct PeerAddressTests {
     let address = PeerAddress(address)
     #expect(address == nil)
   }
+
+  @Test("Int.init(utf8View:)")
+  func testIntInitFromUTF8View() async throws {
+    #expect(54321 == Int(utf8View: "54321".utf8[...]))
+  }
 }


### PR DESCRIPTION
`PeerAddress/init` currently uses `String` and `split`s them, which is not very optimal. This PR uses UTF8View instead to avoid allocations/make things faster