### PR TITLE
Fix metadata check in interop tests

### DIFF
--- a/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
@@ -707,13 +707,13 @@ struct CustomMetadata: InteroperabilityTest {
   let trailingMetadataValue: [UInt8] = [0xAB, 0xAB, 0xAB]
 
   func checkInitialMetadata(_ metadata: Metadata) throws {
-    let values = metadata[self.initialMetadataName]
-    try assertEqual(Array(values), [.string(self.initialMetadataValue)])
+    let values = metadata[stringValues: self.initialMetadataName]
+    try assertEqual(Array(values), [self.initialMetadataValue])
   }
 
   func checkTrailingMetadata(_ metadata: Metadata) throws {
-    let values = metadata[self.trailingMetadataName]
-    try assertEqual(Array(values), [.binary(self.trailingMetadataValue)])
+    let values = metadata[binaryValues: self.trailingMetadataName]
+    try assertEqual(Array(values), [self.trailingMetadataValue])
   }
 
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {


### PR DESCRIPTION
Motivation:

The custom-metadata interop tests checks the underlying element is a decoded `.binary` element. This is isn't guaranteed for binary metadata values as the transport may not decode them. The test should instead check that the _binary values_ for the key are as expected.

Modifications:

- Use `subscript(binaryValues:)` and `subscript(stringValues:)`

Result:

More correct test