### PR TITLE
Update min version of grpc-swift to fix static Linux SDK build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    from: "2.0.0"
+    from: "2.1.1"
   ),
   .package(
     url: "https://github.com/grpc/grpc-swift-protobuf.git",


### PR DESCRIPTION
https://github.com/grpc/grpc-swift/releases/tag/2.1.1 fixes an issue that made `grpc-swift` not compile using the static Linux SDK. This caused issues when trying to build `grpc-swift-extras` using the static Linux SDK. This PR updates the minimum `grpc-swift` version to make it build successfully.