### PR TITLE
Update generated code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let products: [Product] = [
 let dependencies: [Package.Dependency] = [
   .package(
     url: "https://github.com/grpc/grpc-swift.git",
-    from: "2.0.0"
+    from: "2.2.0"
   ),
   .package(
     url: "https://github.com/grpc/grpc-swift-protobuf.git",

--- a/Sources/GRPCHealthService/Generated/health.grpc.swift
+++ b/Sources/GRPCHealthService/Generated/health.grpc.swift
@@ -31,6 +31,7 @@ internal import GRPCProtobuf
 // MARK: - grpc.health.v1.Health
 
 /// Namespace containing generated types for the "grpc.health.v1.Health" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package enum Grpc_Health_V1_Health {
     /// Service descriptor for the "grpc.health.v1.Health" service.
     package static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.health.v1.Health")
@@ -68,6 +69,7 @@ package enum Grpc_Health_V1_Health {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "grpc.health.v1.Health" service.
     package static let grpc_health_v1_Health = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.health.v1.Health")
@@ -75,6 +77,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: grpc.health.v1.Health (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health {
     /// Streaming variant of the service protocol for the "grpc.health.v1.Health" service.
     ///
@@ -299,6 +302,7 @@ extension Grpc_Health_V1_Health {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.StreamingServiceProtocol {
     package func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
         router.registerHandler(
@@ -327,6 +331,7 @@ extension Grpc_Health_V1_Health.StreamingServiceProtocol {
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ServiceProtocol {
     package func check(
         request: GRPCCore.StreamingServerRequest<Grpc_Health_V1_HealthCheckRequest>,
@@ -352,6 +357,7 @@ extension Grpc_Health_V1_Health.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.SimpleServiceProtocol {
     package func check(
         request: GRPCCore.ServerRequest<Grpc_Health_V1_HealthCheckRequest>,
@@ -386,6 +392,7 @@ extension Grpc_Health_V1_Health.SimpleServiceProtocol {
 
 // MARK: grpc.health.v1.Health (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health {
     /// Generated client protocol for the "grpc.health.v1.Health" service.
     ///
@@ -580,6 +587,7 @@ extension Grpc_Health_V1_Health {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ClientProtocol {
     /// Call the "Check" method.
     ///
@@ -661,6 +669,7 @@ extension Grpc_Health_V1_Health.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Health_V1_Health.ClientProtocol {
     /// Call the "Check" method.
     ///

--- a/Sources/GRPCInteropTests/Generated/empty_service.grpc.swift
+++ b/Sources/GRPCInteropTests/Generated/empty_service.grpc.swift
@@ -28,6 +28,7 @@ internal import GRPCProtobuf
 // MARK: - grpc.testing.EmptyService
 
 /// Namespace containing generated types for the "grpc.testing.EmptyService" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public enum Grpc_Testing_EmptyService {
     /// Service descriptor for the "grpc.testing.EmptyService" service.
     public static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.EmptyService")
@@ -38,6 +39,7 @@ public enum Grpc_Testing_EmptyService {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "grpc.testing.EmptyService" service.
     public static let grpc_testing_EmptyService = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.EmptyService")
@@ -45,6 +47,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: grpc.testing.EmptyService (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService {
     /// Streaming variant of the service protocol for the "grpc.testing.EmptyService" service.
     ///
@@ -91,20 +94,24 @@ extension Grpc_Testing_EmptyService {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.StreamingServiceProtocol {
     public func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {}
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.SimpleServiceProtocol {
 }
 
 // MARK: grpc.testing.EmptyService (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService {
     /// Generated client protocol for the "grpc.testing.EmptyService" service.
     ///
@@ -141,9 +148,11 @@ extension Grpc_Testing_EmptyService {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_EmptyService.ClientProtocol {
 }

--- a/Sources/GRPCInteropTests/Generated/test.grpc.swift
+++ b/Sources/GRPCInteropTests/Generated/test.grpc.swift
@@ -31,6 +31,7 @@ internal import GRPCProtobuf
 // MARK: - grpc.testing.TestService
 
 /// Namespace containing generated types for the "grpc.testing.TestService" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public enum Grpc_Testing_TestService {
     /// Service descriptor for the "grpc.testing.TestService" service.
     public static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.TestService")
@@ -146,6 +147,7 @@ public enum Grpc_Testing_TestService {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "grpc.testing.TestService" service.
     public static let grpc_testing_TestService = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.TestService")
@@ -153,6 +155,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: grpc.testing.TestService (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService {
     /// Streaming variant of the service protocol for the "grpc.testing.TestService" service.
     ///
@@ -664,6 +667,7 @@ extension Grpc_Testing_TestService {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.StreamingServiceProtocol {
     public func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
         router.registerHandler(
@@ -758,6 +762,7 @@ extension Grpc_Testing_TestService.StreamingServiceProtocol {
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ServiceProtocol {
     public func emptyCall(
         request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
@@ -827,6 +832,7 @@ extension Grpc_Testing_TestService.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.SimpleServiceProtocol {
     public func emptyCall(
         request: GRPCCore.ServerRequest<Grpc_Testing_Empty>,
@@ -947,6 +953,7 @@ extension Grpc_Testing_TestService.SimpleServiceProtocol {
 
 // MARK: grpc.testing.TestService (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService {
     /// Generated client protocol for the "grpc.testing.TestService" service.
     ///
@@ -1453,6 +1460,7 @@ extension Grpc_Testing_TestService {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ClientProtocol {
     /// Call the "EmptyCall" method.
     ///
@@ -1692,6 +1700,7 @@ extension Grpc_Testing_TestService.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_TestService.ClientProtocol {
     /// Call the "EmptyCall" method.
     ///
@@ -1968,6 +1977,7 @@ extension Grpc_Testing_TestService.ClientProtocol {
 // MARK: - grpc.testing.UnimplementedService
 
 /// Namespace containing generated types for the "grpc.testing.UnimplementedService" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public enum Grpc_Testing_UnimplementedService {
     /// Service descriptor for the "grpc.testing.UnimplementedService" service.
     public static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.UnimplementedService")
@@ -1992,6 +2002,7 @@ public enum Grpc_Testing_UnimplementedService {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "grpc.testing.UnimplementedService" service.
     public static let grpc_testing_UnimplementedService = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.UnimplementedService")
@@ -1999,6 +2010,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: grpc.testing.UnimplementedService (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService {
     /// Streaming variant of the service protocol for the "grpc.testing.UnimplementedService" service.
     ///
@@ -2099,6 +2111,7 @@ extension Grpc_Testing_UnimplementedService {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
     public func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
         router.registerHandler(
@@ -2116,6 +2129,7 @@ extension Grpc_Testing_UnimplementedService.StreamingServiceProtocol {
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ServiceProtocol {
     public func unimplementedCall(
         request: GRPCCore.StreamingServerRequest<Grpc_Testing_Empty>,
@@ -2130,6 +2144,7 @@ extension Grpc_Testing_UnimplementedService.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.SimpleServiceProtocol {
     public func unimplementedCall(
         request: GRPCCore.ServerRequest<Grpc_Testing_Empty>,
@@ -2147,6 +2162,7 @@ extension Grpc_Testing_UnimplementedService.SimpleServiceProtocol {
 
 // MARK: grpc.testing.UnimplementedService (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService {
     /// Generated client protocol for the "grpc.testing.UnimplementedService" service.
     ///
@@ -2240,6 +2256,7 @@ extension Grpc_Testing_UnimplementedService {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ClientProtocol {
     /// Call the "UnimplementedCall" method.
     ///
@@ -2272,6 +2289,7 @@ extension Grpc_Testing_UnimplementedService.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_UnimplementedService.ClientProtocol {
     /// Call the "UnimplementedCall" method.
     ///
@@ -2310,6 +2328,7 @@ extension Grpc_Testing_UnimplementedService.ClientProtocol {
 // MARK: - grpc.testing.ReconnectService
 
 /// Namespace containing generated types for the "grpc.testing.ReconnectService" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 public enum Grpc_Testing_ReconnectService {
     /// Service descriptor for the "grpc.testing.ReconnectService" service.
     public static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.ReconnectService")
@@ -2347,6 +2366,7 @@ public enum Grpc_Testing_ReconnectService {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "grpc.testing.ReconnectService" service.
     public static let grpc_testing_ReconnectService = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.testing.ReconnectService")
@@ -2354,6 +2374,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: grpc.testing.ReconnectService (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService {
     /// Streaming variant of the service protocol for the "grpc.testing.ReconnectService" service.
     ///
@@ -2481,6 +2502,7 @@ extension Grpc_Testing_ReconnectService {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
     public func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
         router.registerHandler(
@@ -2509,6 +2531,7 @@ extension Grpc_Testing_ReconnectService.StreamingServiceProtocol {
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ServiceProtocol {
     public func start(
         request: GRPCCore.StreamingServerRequest<Grpc_Testing_ReconnectParams>,
@@ -2534,6 +2557,7 @@ extension Grpc_Testing_ReconnectService.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.SimpleServiceProtocol {
     public func start(
         request: GRPCCore.ServerRequest<Grpc_Testing_ReconnectParams>,
@@ -2564,6 +2588,7 @@ extension Grpc_Testing_ReconnectService.SimpleServiceProtocol {
 
 // MARK: grpc.testing.ReconnectService (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService {
     /// Generated client protocol for the "grpc.testing.ReconnectService" service.
     ///
@@ -2696,6 +2721,7 @@ extension Grpc_Testing_ReconnectService {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ClientProtocol {
     /// Call the "Start" method.
     ///
@@ -2749,6 +2775,7 @@ extension Grpc_Testing_ReconnectService.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Testing_ReconnectService.ClientProtocol {
     /// Call the "Start" method.
     ///

--- a/Sources/GRPCReflectionService/Generated/reflection.grpc.swift
+++ b/Sources/GRPCReflectionService/Generated/reflection.grpc.swift
@@ -35,6 +35,7 @@ internal import GRPCProtobuf
 // MARK: - grpc.reflection.v1.ServerReflection
 
 /// Namespace containing generated types for the "grpc.reflection.v1.ServerReflection" service.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 package enum Grpc_Reflection_V1_ServerReflection {
     /// Service descriptor for the "grpc.reflection.v1.ServerReflection" service.
     package static let descriptor = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.reflection.v1.ServerReflection")
@@ -59,6 +60,7 @@ package enum Grpc_Reflection_V1_ServerReflection {
     }
 }
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension GRPCCore.ServiceDescriptor {
     /// Service descriptor for the "grpc.reflection.v1.ServerReflection" service.
     package static let grpc_reflection_v1_ServerReflection = GRPCCore.ServiceDescriptor(fullyQualifiedService: "grpc.reflection.v1.ServerReflection")
@@ -66,6 +68,7 @@ extension GRPCCore.ServiceDescriptor {
 
 // MARK: grpc.reflection.v1.ServerReflection (server)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection {
     /// Streaming variant of the service protocol for the "grpc.reflection.v1.ServerReflection" service.
     ///
@@ -155,6 +158,7 @@ extension Grpc_Reflection_V1_ServerReflection {
 }
 
 // Default implementation of 'registerMethods(with:)'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection.StreamingServiceProtocol {
     package func registerMethods<Transport>(with router: inout GRPCCore.RPCRouter<Transport>) where Transport: GRPCCore.ServerTransport {
         router.registerHandler(
@@ -172,10 +176,12 @@ extension Grpc_Reflection_V1_ServerReflection.StreamingServiceProtocol {
 }
 
 // Default implementation of streaming methods from 'StreamingServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection.ServiceProtocol {
 }
 
 // Default implementation of methods from 'ServiceProtocol'.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection.SimpleServiceProtocol {
     package func serverReflectionInfo(
         request: GRPCCore.StreamingServerRequest<Grpc_Reflection_V1_ServerReflectionRequest>,
@@ -197,6 +203,7 @@ extension Grpc_Reflection_V1_ServerReflection.SimpleServiceProtocol {
 
 // MARK: grpc.reflection.v1.ServerReflection (client)
 
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection {
     /// Generated client protocol for the "grpc.reflection.v1.ServerReflection" service.
     ///
@@ -280,6 +287,7 @@ extension Grpc_Reflection_V1_ServerReflection {
 }
 
 // Helpers providing default arguments to 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection.ClientProtocol {
     /// Call the "ServerReflectionInfo" method.
     ///
@@ -311,6 +319,7 @@ extension Grpc_Reflection_V1_ServerReflection.ClientProtocol {
 }
 
 // Helpers providing sugared APIs for 'ClientProtocol' methods.
+@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Grpc_Reflection_V1_ServerReflection.ClientProtocol {
     /// Call the "ServerReflectionInfo" method.
     ///


### PR DESCRIPTION
Motivation:

grpc-swift 2.2.0 added availability annotations to generated code. The CI job checking generated code is now failing..

Modifications:

Regenerate

Result:

CI passes