### PR TITLE
Move availability inline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
 
   static-sdk:
     name: Static SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,10 +22,10 @@ jobs:
     with:
       linux_5_9_enabled: false
       linux_5_10_enabled: false
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors -Xswiftc -require-explicit-availability"
+      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-availability"
 
   cxx-interop:
     name: Cxx interop

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/grpc/grpc-swift-protobuf.git",
-    from: "1.0.0"
+    from: "1.3.0"
   ),
   .package(
     url: "https://github.com/apple/swift-protobuf.git",
@@ -59,16 +59,32 @@ let dependencies: [Package.Dependency] = [
   ),
   .package(
     url: "https://github.com/swift-server/swift-service-lifecycle.git",
-    from: "2.6.3"
+    from: "2.8.0"
   ),
 ]
 
-let defaultSwiftSettings: [SwiftSetting] = [
-  .swiftLanguageMode(.v6),
-  .enableUpcomingFeature("ExistentialAny"),
-  .enableUpcomingFeature("InternalImportsByDefault"),
-  .enableUpcomingFeature("MemberImportVisibility"),
-]
+// -------------------------------------------------------------------------------------------------
+
+// This adds some build settings which allow us to map "@available(gRPCSwiftExtras 1.x, *)" to
+// the appropriate OS platforms.
+let nextMinorVersion = 1
+let availabilitySettings: [SwiftSetting] = (0 ... nextMinorVersion).map { minor in
+  let name = "gRPCSwiftExtras"
+  let version = "1.\(minor)"
+  let platforms = "macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0"
+  let setting = "AvailabilityMacro=\(name) \(version):\(platforms)"
+  return .enableExperimentalFeature(setting)
+}
+
+let defaultSwiftSettings: [SwiftSetting] =
+  availabilitySettings + [
+    .swiftLanguageMode(.v6),
+    .enableUpcomingFeature("ExistentialAny"),
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+  ]
+
+// -------------------------------------------------------------------------------------------------
 
 let targets: [Target] = [
   // An implementation of the gRPC Health service.
@@ -177,13 +193,6 @@ let targets: [Target] = [
 
 let package = Package(
   name: "grpc-swift-extras",
-  platforms: [
-    .macOS(.v15),
-    .iOS(.v18),
-    .tvOS(.v18),
-    .watchOS(.v11),
-    .visionOS(.v2),
-  ],
   products: products,
   dependencies: dependencies,
   targets: targets

--- a/Sources/GRPCHealthService/HealthService+Service.swift
+++ b/Sources/GRPCHealthService/HealthService+Service.swift
@@ -17,12 +17,14 @@
 internal import GRPCCore
 private import Synchronization
 
+@available(gRPCSwiftExtras 1.0, *)
 extension HealthService {
   internal struct Service: Grpc_Health_V1_Health.ServiceProtocol {
     private let state = Self.State()
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension HealthService.Service {
   func check(
     request: ServerRequest<Grpc_Health_V1_HealthCheckRequest>,
@@ -69,6 +71,7 @@ extension HealthService.Service {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension HealthService.Service {
   private final class State: Sendable {
     // The state of each service keyed by the fully qualified service name.

--- a/Sources/GRPCHealthService/HealthService.swift
+++ b/Sources/GRPCHealthService/HealthService.swift
@@ -41,6 +41,7 @@ public import GRPCCore
 ///   // ...
 /// }
 /// ```
+@available(gRPCSwiftExtras 1.0, *)
 public struct HealthService: Sendable, RegistrableRPCService {
   /// An implementation of the `grpc.health.v1.Health` service.
   private let service: Service
@@ -62,6 +63,7 @@ public struct HealthService: Sendable, RegistrableRPCService {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension HealthService {
   /// Provides status updates to ``HealthService``.
   public struct Provider: Sendable {
@@ -105,6 +107,7 @@ extension HealthService {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension Grpc_Health_V1_HealthCheckResponse.ServingStatus {
   package init(_ status: ServingStatus) {
     switch status.value {

--- a/Sources/GRPCHealthService/ServingStatus.swift
+++ b/Sources/GRPCHealthService/ServingStatus.swift
@@ -18,6 +18,7 @@
 ///
 /// - ``ServingStatus/serving`` indicates that a service is healthy.
 /// - ``ServingStatus/notServing`` indicates that a service is unhealthy.
+@available(gRPCSwiftExtras 1.0, *)
 public struct ServingStatus: Sendable, Hashable {
   internal enum Value: Sendable, Hashable {
     case serving

--- a/Sources/GRPCInteropTests/AssertionFailure.swift
+++ b/Sources/GRPCInteropTests/AssertionFailure.swift
@@ -17,6 +17,7 @@
 /// Failure assertion for interoperability testing.
 ///
 /// This is required because the tests must be able to run without XCTest.
+@available(gRPCSwiftExtras 1.0, *)
 public struct AssertionFailure: Error {
   public var message: String
   public var file: String
@@ -30,6 +31,7 @@ public struct AssertionFailure: Error {
 }
 
 /// Asserts that the value of an expression is `true`.
+@available(gRPCSwiftExtras 1.0, *)
 public func assertTrue(
   _ expression: @autoclosure () throws -> Bool,
   _ message: String = "The statement is not true.",
@@ -42,6 +44,7 @@ public func assertTrue(
 }
 
 /// Asserts that the two given values are equal.
+@available(gRPCSwiftExtras 1.0, *)
 public func assertEqual<T: Equatable>(
   _ value1: T,
   _ value2: T,

--- a/Sources/GRPCInteropTests/InteroperabilityTestCase.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCase.swift
@@ -15,6 +15,7 @@
  */
 public import GRPCCore
 
+@available(gRPCSwiftExtras 1.0, *)
 public protocol InteroperabilityTest {
   /// Run a test case using the given connection.
   ///
@@ -47,6 +48,7 @@ public protocol InteroperabilityTest {
 /// Note: Tests for compression have not been implemented yet as compression is
 /// not supported. Once the API which allows for compression will be implemented
 /// these tests should be added.
+@available(gRPCSwiftExtras 1.0, *)
 public enum InteroperabilityTestCase: String, CaseIterable, Sendable {
   case emptyUnary = "empty_unary"
   case largeUnary = "large_unary"
@@ -68,6 +70,7 @@ public enum InteroperabilityTestCase: String, CaseIterable, Sendable {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension InteroperabilityTestCase {
   /// Return a new instance of the test case.
   public func makeTest() -> any InteroperabilityTest {

--- a/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCases.swift
@@ -36,6 +36,7 @@ private import struct Foundation.Data
 /// Client asserts:
 /// - call was successful
 /// - response is non-null
+@available(gRPCSwiftExtras 1.0, *)
 struct EmptyUnary: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -69,6 +70,7 @@ struct EmptyUnary: InteroperabilityTest {
 /// - response payload body is 314159 bytes in size
 /// - clients are free to assert that the response payload body contents are zero and comparing
 ///   the entire response message against a golden response
+@available(gRPCSwiftExtras 1.0, *)
 struct LargeUnary: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -144,6 +146,7 @@ struct LargeUnary: InteroperabilityTest {
 /// - Response payload body is 314159 bytes in size.
 /// - Clients are free to assert that the response payload body contents are zeros and comparing the
 ///   entire response message against a golden response.
+@available(gRPCSwiftExtras 1.0, *)
 class ClientCompressedUnary: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -253,6 +256,7 @@ class ClientCompressedUnary: InteroperabilityTest {
 /// - response payload body is 314159 bytes in size in both cases.
 /// - clients are free to assert that the response payload body contents are zero and comparing the
 ///   entire response message against a golden response
+@available(gRPCSwiftExtras 1.0, *)
 class ServerCompressedUnary: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -342,6 +346,7 @@ class ServerCompressedUnary: InteroperabilityTest {
 /// Client asserts:
 /// - call was successful
 /// - response aggregated_payload_size is 74922
+@available(gRPCSwiftExtras 1.0, *)
 struct ClientStreaming: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -392,6 +397,7 @@ struct ClientStreaming: InteroperabilityTest {
 /// - response payload bodies are sized (in order): 31415, 9, 2653, 58979
 /// - clients are free to assert that the response payload body contents are zero and
 ///   comparing the entire response messages against golden responses
+@available(gRPCSwiftExtras 1.0, *)
 struct ServerStreaming: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -467,6 +473,7 @@ struct ServerStreaming: InteroperabilityTest {
 /// - response payload bodies are sized (in order): 31415, 92653
 /// - clients are free to assert that the response payload body contents are zero and comparing the
 ///   entire response messages against golden responses
+@available(gRPCSwiftExtras 1.0, *)
 class ServerCompressedStreaming: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -579,6 +586,7 @@ class ServerCompressedStreaming: InteroperabilityTest {
 /// - response payload bodies are sized (in order): 31415, 9, 2653, 58979
 /// - clients are free to assert that the response payload body contents are zero and
 ///   comparing the entire response messages against golden responses
+@available(gRPCSwiftExtras 1.0, *)
 struct PingPong: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -645,6 +653,7 @@ struct PingPong: InteroperabilityTest {
 /// Client asserts:
 /// - call was successful
 /// - exactly zero responses
+@available(gRPCSwiftExtras 1.0, *)
 struct EmptyStream: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -700,6 +709,7 @@ struct EmptyStream: InteroperabilityTest {
 ///   received in the initial metadata for calls in Procedure steps 1 and 2.
 /// - metadata with key "x-grpc-test-echo-trailing-bin" and value 0xababab is received in the
 ///   trailing metadata for calls in Procedure steps 1 and 2.
+@available(gRPCSwiftExtras 1.0, *)
 struct CustomMetadata: InteroperabilityTest {
   let initialMetadataName = "x-grpc-test-echo-initial"
   let initialMetadataValue = "test_initial_metadata_value"
@@ -820,6 +830,7 @@ struct CustomMetadata: InteroperabilityTest {
 /// Client asserts:
 /// - received status code is the same as the sent code for both Procedure steps 1 and 2
 /// - received status message is the same as the sent message for both Procedure steps 1 and 2
+@available(gRPCSwiftExtras 1.0, *)
 struct StatusCodeAndMessage: InteroperabilityTest {
   let expectedCode = 2
   let expectedMessage = "test status message"
@@ -897,6 +908,7 @@ struct StatusCodeAndMessage: InteroperabilityTest {
 /// - received status code is the same as the sent code for Procedure step 1
 /// - received status message is the same as the sent message for Procedure step 1, including all
 ///   whitespace characters
+@available(gRPCSwiftExtras 1.0, *)
 struct SpecialStatusMessage: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -939,6 +951,7 @@ struct SpecialStatusMessage: InteroperabilityTest {
 ///
 /// Client asserts:
 /// - received status code is 12 (UNIMPLEMENTED)
+@available(gRPCSwiftExtras 1.0, *)
 struct UnimplementedMethod: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let testServiceClient = Grpc_Testing_TestService.Client(wrapping: client)
@@ -971,6 +984,7 @@ struct UnimplementedMethod: InteroperabilityTest {
 ///
 /// Client asserts:
 /// - received status code is 12 (UNIMPLEMENTED)
+@available(gRPCSwiftExtras 1.0, *)
 struct UnimplementedService: InteroperabilityTest {
   func run<Transport: ClientTransport>(client: GRPCClient<Transport>) async throws {
     let unimplementedServiceClient = Grpc_Testing_UnimplementedService.Client(wrapping: client)

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -23,6 +23,7 @@ private import struct FoundationEssentials.Data
 private import struct Foundation.Data
 #endif
 
+@available(gRPCSwiftExtras 1.0, *)
 public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}
 
@@ -233,6 +234,7 @@ public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension Metadata {
   fileprivate func makeInitialAndTrailingMetadata() -> (Metadata, Metadata) {
     var initialMetadata = Metadata()

--- a/Sources/GRPCOTelTracingInterceptors/HookedAsyncSequence.swift
+++ b/Sources/GRPCOTelTracingInterceptors/HookedAsyncSequence.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@available(gRPCSwiftExtras 1.0, *)
 internal struct HookedRPCAsyncSequence<Wrapped: AsyncSequence & Sendable>: AsyncSequence, Sendable
 where Wrapped.Element: Sendable {
   private let wrapped: Wrapped

--- a/Sources/GRPCOTelTracingInterceptors/HookedWriter.swift
+++ b/Sources/GRPCOTelTracingInterceptors/HookedWriter.swift
@@ -16,6 +16,7 @@
 internal import GRPCCore
 internal import Tracing
 
+@available(gRPCSwiftExtras 1.0, *)
 struct HookedWriter<Element: Sendable>: RPCWriterProtocol {
   private let writer: any RPCWriterProtocol<Element>
   private let afterEachWrite: @Sendable () -> Void

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -29,6 +29,7 @@ package import Tracing
 /// OpenTelemetry's documentation on:
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
+@available(gRPCSwiftExtras 1.0, *)
 public struct ClientOTelTracingInterceptor: ClientInterceptor {
   private let injector: ClientRequestInjector
   private var serverHostname: String
@@ -241,6 +242,7 @@ public struct ClientOTelTracingInterceptor: ClientInterceptor {
 
 /// An injector responsible for injecting the required instrumentation keys from the `ServiceContext` into
 /// the request metadata.
+@available(gRPCSwiftExtras 1.0, *)
 struct ClientRequestInjector: Instrumentation.Injector {
   typealias Carrier = Metadata
 
@@ -249,6 +251,7 @@ struct ClientRequestInjector: Instrumentation.Injector {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension Error {
   var grpcErrorCode: RPCError.Code? {
     if let rpcError = self as? RPCError {

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -28,6 +28,7 @@ package import Tracing
 /// OpenTelemetry's documentation on:
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
+@available(gRPCSwiftExtras 1.0, *)
 public struct ServerOTelTracingInterceptor: ServerInterceptor {
   private let extractor: ServerRequestExtractor
   private var serverHostname: String
@@ -217,6 +218,7 @@ public struct ServerOTelTracingInterceptor: ServerInterceptor {
 }
 
 /// An extractor responsible for extracting the required instrumentation keys from request metadata.
+@available(gRPCSwiftExtras 1.0, *)
 struct ServerRequestExtractor: Instrumentation.Extractor {
   typealias Carrier = Metadata
 

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/SpanAttributes+GRPCTracingKeys.swift
@@ -40,6 +40,7 @@ enum GRPCTracingKeys {
   fileprivate static let responseMetadataPrefix = "rpc.grpc.response.metadata."
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension Span {
   // See: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/
   func setOTelClientSpanGRPCAttributes(

--- a/Sources/GRPCReflectionService/Service/ReflectionService+V1.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionService+V1.swift
@@ -17,6 +17,7 @@
 internal import GRPCCore
 internal import SwiftProtobuf
 
+@available(gRPCSwiftExtras 1.0, *)
 extension ReflectionService {
   struct V1: Grpc_Reflection_V1_ServerReflection.SimpleServiceProtocol {
     private typealias Response = Grpc_Reflection_V1_ServerReflectionResponse
@@ -31,6 +32,7 @@ extension ReflectionService {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension ReflectionService.V1 {
   private func findFileByFileName(_ fileName: String) throws(RPCError) -> FileDescriptorResponse {
     let data = try self.registry.serialisedFileDescriptorForDependenciesOfFile(named: fileName)

--- a/Sources/GRPCReflectionService/Service/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionService.swift
@@ -33,6 +33,7 @@ public import struct Foundation.Data
 ///
 /// The service will offer information to clients about any registered services. You can register
 /// a service by providing its descriptor set to the service.
+@available(gRPCSwiftExtras 1.0, *)
 public struct ReflectionService: Sendable {
   private let service: ReflectionService.V1
 
@@ -67,6 +68,7 @@ public struct ReflectionService: Sendable {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension ReflectionService: RegistrableRPCService {
   public func registerMethods<Transport>(
     with router: inout RPCRouter<Transport>
@@ -75,6 +77,7 @@ extension ReflectionService: RegistrableRPCService {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension ReflectionService {
   static func readSerializedFileDescriptorProto(
     atPath path: String

--- a/Sources/GRPCReflectionService/Service/ReflectionServiceRegistry.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionServiceRegistry.swift
@@ -24,6 +24,7 @@ package import struct FoundationEssentials.Data
 package import struct Foundation.Data
 #endif
 
+@available(gRPCSwiftExtras 1.0, *)
 package struct ReflectionServiceRegistry: Sendable {
   private struct SerializedFileDescriptor: Sendable {
     var bytes: Data

--- a/Sources/GRPCServiceLifecycle/GRPCClient+Service.swift
+++ b/Sources/GRPCServiceLifecycle/GRPCClient+Service.swift
@@ -19,6 +19,7 @@ public import ServiceLifecycle
 
 // A `@retroactive` conformance here is okay because this project is also owned by the owners of
 // `GRPCCore`, and thus, the owners of `GRPCClient`. A conflicting conformance won't be added.
+@available(gRPCSwiftExtras 1.0, *)
 extension GRPCClient: @retroactive Service {
   public func run() async throws {
     try await withGracefulShutdownHandler {

--- a/Sources/GRPCServiceLifecycle/GRPCServer+Service.swift
+++ b/Sources/GRPCServiceLifecycle/GRPCServer+Service.swift
@@ -19,6 +19,7 @@ public import ServiceLifecycle
 
 // A `@retroactive` conformance here is okay because this project is also owned by the owners of
 // `GRPCCore`, and thus, the owners of `GRPCServer`. A conflicting conformance won't be added.
+@available(gRPCSwiftExtras 1.0, *)
 extension GRPCServer: @retroactive Service {
   public func run() async throws {
     try await withGracefulShutdownHandler {

--- a/Tests/GRPCHealthServiceTests/HealthTests.swift
+++ b/Tests/GRPCHealthServiceTests/HealthTests.swift
@@ -20,6 +20,7 @@ import GRPCInProcessTransport
 import SwiftProtobuf
 import XCTest
 
+@available(gRPCSwiftExtras 1.0, *)
 final class HealthTests: XCTestCase {
   private func withHealthClient(
     _ body: @Sendable (
@@ -286,6 +287,7 @@ final class HealthTests: XCTestCase {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 extension ServiceDescriptor {
   fileprivate static let testService = ServiceDescriptor(package: "test", service: "Service")
 }

--- a/Tests/GRPCOTelTracingInterceptorsTests/TracingTestsUtilities.swift
+++ b/Tests/GRPCOTelTracingInterceptorsTests/TracingTestsUtilities.swift
@@ -18,6 +18,7 @@ import GRPCCore
 import Synchronization
 import Tracing
 
+@available(gRPCSwiftExtras 1.0, *)
 final class TestTracer: Tracer {
   typealias Span = TestSpan
 
@@ -71,6 +72,7 @@ final class TestTracer: Tracer {
   }
 }
 
+@available(gRPCSwiftExtras 1.0, *)
 final class TestSpan: Span, Sendable {
   private struct State {
     var context: ServiceContextModule.ServiceContext

--- a/Tests/GRPCReflectionServiceTests/GRPCReflectionServiceTests.swift
+++ b/Tests/GRPCReflectionServiceTests/GRPCReflectionServiceTests.swift
@@ -23,6 +23,7 @@ import Testing
 
 @Suite("gRPC Reflection Service Tests")
 struct GRPCReflectionServiceTests {
+  @available(gRPCSwiftExtras 1.0, *)
   func withReflectionClient(
     descriptorSetPaths: [String] = Bundle.module.pathsForDescriptorSets,
     execute body: (ReflectionClient) async throws -> Void
@@ -39,6 +40,7 @@ struct GRPCReflectionServiceTests {
   }
 
   @Test("List services")
+  @available(gRPCSwiftExtras 1.0, *)
   func listServices() async throws {
     try await self.withReflectionClient { reflection in
       let services = try await reflection.listServices()
@@ -57,6 +59,7 @@ struct GRPCReflectionServiceTests {
       "grpc/health/v1/health.proto",
     ]
   )
+  @available(gRPCSwiftExtras 1.0, *)
   func fileByFileName(fileName: String) async throws {
     try await self.withReflectionClient { reflection in
       let descriptors = try await reflection.fileByFileName(fileName)
@@ -66,6 +69,7 @@ struct GRPCReflectionServiceTests {
   }
 
   @Test("File by file name (doesn't exist)")
+  @available(gRPCSwiftExtras 1.0, *)
   func testFileByNonExistentFileName() async throws {
     try await self.withReflectionClient { reflection in
       await #expect {
@@ -89,6 +93,7 @@ struct GRPCReflectionServiceTests {
       ("grpc/reflection/v1/reflection.proto", "grpc.reflection.v1.ErrorResponse"),
     ] as [(String, String)]
   )
+  @available(gRPCSwiftExtras 1.0, *)
   func fileContainingSymbol(fileName: String, symbol: String) async throws {
     try await self.withReflectionClient { reflection in
       let descriptors = try await reflection.fileContainingSymbol(symbol)
@@ -98,6 +103,7 @@ struct GRPCReflectionServiceTests {
   }
 
   @Test("File containing symbol includes dependencies")
+  @available(gRPCSwiftExtras 1.0, *)
   func fileContainingSymbolWithDependency() async throws {
     try await self.withReflectionClient { reflection in
       let descriptors = try await reflection.fileContainingSymbol(".MessageWithDependency")
@@ -107,6 +113,7 @@ struct GRPCReflectionServiceTests {
   }
 
   @Test("File containing symbol (doesn't exist)")
+  @available(gRPCSwiftExtras 1.0, *)
   func testFileContainingNonExistentSymbol() async throws {
     try await self.withReflectionClient { reflection in
       await #expect {
@@ -121,6 +128,7 @@ struct GRPCReflectionServiceTests {
   }
 
   @Test("File containing extension")
+  @available(gRPCSwiftExtras 1.0, *)
   func testFileContainingExtension() async throws {
     try await self.withReflectionClient { reflection in
       let descriptors = try await reflection.fileContainingExtension(number: 100, in: "BaseMessage")
@@ -130,6 +138,7 @@ struct GRPCReflectionServiceTests {
   }
 
   @Test("File containing extension (doesn't exist)")
+  @available(gRPCSwiftExtras 1.0, *)
   func testFileContainingNonExistentExtension() async throws {
     try await self.withReflectionClient { reflection in
       await #expect {

--- a/Tests/GRPCReflectionServiceTests/ReflectionClient.swift
+++ b/Tests/GRPCReflectionServiceTests/ReflectionClient.swift
@@ -19,6 +19,7 @@ import GRPCInProcessTransport
 import GRPCReflectionService
 import SwiftProtobuf
 
+@available(gRPCSwiftExtras 1.0, *)
 struct ReflectionClient: Sendable {
   private typealias Request = Grpc_Reflection_V1_ServerReflectionRequest
   private let stub: Grpc_Reflection_V1_ServerReflection.Client<InProcessTransport.Client>

--- a/Tests/GRPCServiceLifecycleTests/ServiceLifecycleConformanceTests.swift
+++ b/Tests/GRPCServiceLifecycleTests/ServiceLifecycleConformanceTests.swift
@@ -23,6 +23,7 @@ import Testing
 @Suite("gRPC ServiceLifecycle/Service conformance tests")
 struct ServiceLifecycleConformanceTests {
   @Test("Client respects graceful shutdown")
+  @available(gRPCSwiftExtras 1.0, *)
   func clientGracefulShutdown() async throws {
     let inProcess = InProcessTransport()
     try await testGracefulShutdown { trigger in
@@ -41,6 +42,7 @@ struct ServiceLifecycleConformanceTests {
   }
 
   @Test("Server respects graceful shutdown")
+  @available(gRPCSwiftExtras 1.0, *)
   func serverGracefulShutdown() async throws {
     let inProcess = InProcessTransport()
     try await testGracefulShutdown { trigger in

--- a/Tests/InProcessInteropTests/InProcessInteroperabilityTests.swift
+++ b/Tests/InProcessInteropTests/InProcessInteroperabilityTests.swift
@@ -19,6 +19,7 @@ import GRPCInProcessTransport
 import GRPCInteropTests
 import XCTest
 
+@available(gRPCSwiftExtras 1.0, *)
 final class InProcessInteroperabilityTests: XCTestCase {
   func runInProcessTransport(
     interopTestCase: InteroperabilityTestCase


### PR DESCRIPTION
Motivation:

It's hard for packages to incrementally adopt gRPC with platforms in the package manifest as it requires packages to include platforms in their manifest or mint a new major version.

Modifications:

- Move platform availability onto source code
- Check annotations in CI

Result:

Easier to adopt