### PR TITLE
Workaround SwiftPM bug for API breakage checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,9 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
       license_header_check_project_name: "gRPC"
+      # This is done by a similar job defined in soundness.yml. It needs to be
+      # separate in order to export an environment variable.
+      api_breakage_check_enabled: false
 
   grpc-soundness:
     name: Soundness

--- a/.github/workflows/soundness.yml
+++ b/.github/workflows/soundness.yml
@@ -35,3 +35,28 @@ jobs:
       - name: Run soundness checks
         run: |
           ./dev/check-generated-code.sh
+
+  api-breakage-check:
+    name: API breakage check
+    runs-on: ubuntu-latest
+    container:
+      image: swift:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0  # Fetching tags requires fetch-depth: 0 (https://github.com/actions/checkout/issues/1471)
+      - name: Mark the workspace as safe
+        # https://github.com/actions/checkout/issues/766
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Run API breakage check
+        shell: bash
+        # See Package.swift in grpc-swift-protobuf for why we set GRPC_SWIFT_PROTOBUF_NO_VERSION=1
+        run: |
+          export GRPC_SWIFT_PROTOBUF_NO_VERSION=1
+
+          git fetch ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} ${GITHUB_BASE_REF}:pull-base-ref
+          BASELINE_REF='pull-base-ref'
+          echo "Using baseline: $BASELINE_REF"
+          swift package diagnose-api-breaking-changes "$BASELINE_REF"


### PR DESCRIPTION
Motivation:

SwiftPM has some issues with the API breakage checker when building packages which contain an executable and/or a C target.

Modifications:

Don't compile the C target when running the breakage checker.

Result:

API breakage checking works