### PR TITLE
Add deprecation warnings

### DIFF
--- a/Sources/GRPCHealthService/HealthService.swift
+++ b/Sources/GRPCHealthService/HealthService.swift
@@ -42,6 +42,7 @@ public import GRPCCore
 /// }
 /// ```
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct HealthService: Sendable, RegistrableRPCService {
   /// An implementation of the `grpc.health.v1.Health` service.
   private let service: Service

--- a/Sources/GRPCInteropTests/InteroperabilityTestCase.swift
+++ b/Sources/GRPCInteropTests/InteroperabilityTestCase.swift
@@ -16,6 +16,7 @@
 public import GRPCCore
 
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public protocol InteroperabilityTest {
   /// Run a test case using the given connection.
   ///

--- a/Sources/GRPCInteropTests/TestService.swift
+++ b/Sources/GRPCInteropTests/TestService.swift
@@ -24,6 +24,7 @@ private import struct Foundation.Data
 #endif
 
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct TestService: Grpc_Testing_TestService.ServiceProtocol {
   public init() {}
 

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ClientOTelTracingInterceptor.swift
@@ -30,6 +30,7 @@ package import Tracing
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct ClientOTelTracingInterceptor: ClientInterceptor {
   private let injector: ClientRequestInjector
   private var serverHostname: String

--- a/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
+++ b/Sources/GRPCOTelTracingInterceptors/Tracing/ServerOTelTracingInterceptor.swift
@@ -29,6 +29,7 @@ package import Tracing
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans
 /// - https://opentelemetry.io/docs/specs/semconv/rpc/grpc/
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct ServerOTelTracingInterceptor: ServerInterceptor {
   private let extractor: ServerRequestExtractor
   private var serverHostname: String

--- a/Sources/GRPCReflectionService/Service/ReflectionService.swift
+++ b/Sources/GRPCReflectionService/Service/ReflectionService.swift
@@ -34,6 +34,7 @@ public import struct Foundation.Data
 /// The service will offer information to clients about any registered services. You can register
 /// a service by providing its descriptor set to the service.
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 public struct ReflectionService: Sendable {
   private let service: ReflectionService.V1
 

--- a/Sources/GRPCServiceLifecycle/GRPCClient+Service.swift
+++ b/Sources/GRPCServiceLifecycle/GRPCClient+Service.swift
@@ -20,6 +20,7 @@ public import ServiceLifecycle
 // A `@retroactive` conformance here is okay because this project is also owned by the owners of
 // `GRPCCore`, and thus, the owners of `GRPCClient`. A conflicting conformance won't be added.
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 extension GRPCClient: @retroactive Service {
   public func run() async throws {
     try await withGracefulShutdownHandler {

--- a/Sources/GRPCServiceLifecycle/GRPCServer+Service.swift
+++ b/Sources/GRPCServiceLifecycle/GRPCServer+Service.swift
@@ -20,6 +20,7 @@ public import ServiceLifecycle
 // A `@retroactive` conformance here is okay because this project is also owned by the owners of
 // `GRPCCore`, and thus, the owners of `GRPCServer`. A conflicting conformance won't be added.
 @available(gRPCSwiftExtras 1.0, *)
+@available(*, deprecated, message: "See https://forums.swift.org/t/80177")
 extension GRPCServer: @retroactive Service {
   public func run() async throws {
     try await withGracefulShutdownHandler {


### PR DESCRIPTION
Motivation:

gRPC Swift v2 has moved to a new repo, grpc-swift-2 and as a result this package has a new major version. That's not all that discoverable.

Modifications:

Deprecate commonly used high-level types with a link to a forums post explaining the move.

Result:

Users are notified about the move