### PR TITLE
Enable release mode builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,5 +26,4 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
-      linux_5_9_enabled: false
       linux_5_10_enabled: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,7 @@ jobs:
   static-sdk:
     name: Static SDK
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,6 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    with:
+      linux_5_9_enabled: false
+      linux_5_10_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,3 +40,7 @@ jobs:
   static-sdk:
     name: Static SDK
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+
+  release-builds:
+    name: Release builds
+    uses: apple/swift-nio/.github/workflows/release_builds.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,5 +45,4 @@ jobs:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
-      linux_5_9_enabled: false
       linux_5_10_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,3 +44,6 @@ jobs:
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
+    with:
+      linux_5_9_enabled: false
+      linux_5_10_enabled: false


### PR DESCRIPTION
### Motivation:

Some errors do not show up in debug builds. Enabling release mode builds improves the CI coverage.

### Modifications:

Enable release mode builds for pull requests and scheduled builds on main.

### Result:

Improved CI coverage.